### PR TITLE
v0.24 - Minor Fixes & Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changelog
   to support multiple connects and disconnects.
 - Added `Chancy.sync_declare()`, `Chancy.sync_declare_ex()` and
   `Chancy.sync_get_job`.
+- Jobs are now naturally fetched oldest to newest due to the nature of the
+  UUID7s that are used for the job IDs. Job features like priority may affect
+  this ordering.
 
 0.23.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Changelog
 - Jobs are now naturally fetched oldest to newest due to the nature of the
   UUID7s that are used for the job IDs. Job features like priority may affect
   this ordering.
+- Added the `worker.queue.full` event to notify when a queue's polling event
+  ran, but was unable to start any jobs due to the executor being full.
 
 0.23.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog
 - Fix for `sync_push_many_ex` using index access for columns instead of key
   by @nico-deforge.
 - Fixed a deprecated usage of `ConnectionPool()` with an implicit `open=True`.
+- Fixed the `queue.pushed` event not waking up a worker waiting for jobs.
 
 ✨ Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,23 @@ Changelog
 0.24.0
 ------
 
-- 📝 Documentation fix to the cron plugin example (Thanks @PaulM5406)
+📝 Documentation
+
+- Correction to the cron plugin example (Thanks @PaulM5406)
+
+🐛 Fixes
+
+- Fix for `sync_push_many_ex` using index access for columns instead of key
+  by @nico-deforge.
+- Fixed a deprecated usage of `ConnectionPool()` with an implicit `open=True`.
+
+✨ Improvements
+
+- Exposed the `created_at` field on a QueuedJob record by @PaulM5406.
+- Erase the cached psycopg pool connection when the context manager is closed
+  to support multiple connects and disconnects.
+- Added `Chancy.sync_declare()`, `Chancy.sync_declare_ex()` and
+  `Chancy.sync_get_job`.
 
 0.23.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.24.0
+------
+
+- 📝 Documentation fix to the cron plugin example (Thanks @PaulM5406)
+
 0.23.0
 ------
 
@@ -17,8 +22,8 @@ Changelog
 0.22.0
 ------
 
-This release requires that you run migrations, as it converts all JSON columns
-to JSONB. Call `chancy.migrate()` or use the CLI:
+🚨 This release requires that you run migrations, as it converts all JSON
+columns to JSONB. Call `chancy.migrate()` or use the CLI:
 
 ```bash
 chancy --app <your app> misc migrate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Changelog
   this ordering.
 - Added the `worker.queue.full` event to notify when a queue's polling event
   ran, but was unable to start any jobs due to the executor being full.
+- If a queue pulled its maximum number of jobs, it'll immediately re-poll for
+  more, as it's unlikely that the queue is now empty.
 
 0.23.0
 ------

--- a/chancy/app.py
+++ b/chancy/app.py
@@ -397,9 +397,7 @@ class Chancy:
                 return queue
 
     @_ensure_sync_pool_is_open
-    def sync_declare(
-        self, queue: Queue, *, upsert: bool = False
-    ) -> Queue:
+    def sync_declare(self, queue: Queue, *, upsert: bool = False) -> Queue:
         """
         Synchronously declare a queue in the database. See :func:`declare` for
         more information.

--- a/chancy/app.py
+++ b/chancy/app.py
@@ -640,7 +640,7 @@ class Chancy:
                 self._get_job_params(job),
             )
             record = cursor.fetchone()
-            references.append(Reference(record[0]))
+            references.append(Reference(record["id"]))
 
         for queue in set(job.queue for job in jobs):
             self.sync_notify(cursor, "queue.pushed", {"q": queue})

--- a/chancy/app.py
+++ b/chancy/app.py
@@ -292,6 +292,9 @@ class Chancy:
             min_size=self.min_connection_pool_size,
             max_size=self.max_connection_pool_size,
             reconnect_timeout=self.poll_reconnect_timeout,
+            # Opening the pool here is deprecated, and should be done
+            # explicitly by the user with a context manager or open/close.
+            open=False,
         )
 
     @_ensure_pool_is_open
@@ -378,6 +381,10 @@ class Chancy:
             async with Chancy("postgresql://localhost/chancy") as chancy:
                 await chancy.declare(Queue("default"))
 
+        .. seealso::
+
+            :meth:`sync_declare` for a synchronous version of this method.
+
         :param queue: The queue to declare.
         :param upsert: If `True`, the queue will be updated if it already
             exists. Defaults to `False`.
@@ -387,6 +394,34 @@ class Chancy:
             async with conn.cursor(row_factory=dict_row) as cursor:
                 queue = await self.declare_ex(cursor, queue, upsert=upsert)
                 await self.notify(cursor, "queue.declared", {"q": queue.name})
+                return queue
+
+    @_ensure_sync_pool_is_open
+    def sync_declare(
+        self, queue: Queue, *, upsert: bool = False
+    ) -> Queue:
+        """
+        Synchronously declare a queue in the database. See :func:`declare` for
+        more information.
+
+        .. code-block:: python
+
+            with Chancy("postgresql://localhost/chancy") as chancy:
+                chancy.sync_declare(Queue("default"))
+
+        .. seealso::
+
+            :meth:`declare` for an asynchronous version of this method.
+
+        :param queue: The queue to declare.
+        :param upsert: If `True`, the queue will be updated if it already
+            exists. Defaults to `False`.
+        :return: The queue as it exists in the database.
+        """
+        with self.sync_pool.connection() as conn:
+            with conn.cursor(row_factory=dict_row) as cursor:
+                queue = self.sync_declare_ex(cursor, queue, upsert=upsert)
+                self.sync_notify(cursor, "queue.declared", {"q": queue.name})
                 return queue
 
     async def declare_ex(
@@ -425,6 +460,46 @@ class Chancy:
         )
 
         result = await cursor.fetchone()
+        return Queue(
+            **{
+                **result,
+                "name": queue.name,
+                "tags": set(result["tags"]),
+            }
+        )
+
+    def sync_declare_ex(
+        self,
+        cursor: Cursor[DictRow],
+        queue: Queue,
+        *,
+        upsert: bool = False,
+    ) -> Queue:
+        """
+        Synchronously declare a queue in the database using a specific cursor.
+        See :func:`declare_ex` for more information.
+
+        .. seealso::
+
+            :meth:`declare_ex` for an asynchronous version of this method.
+        """
+        cursor.execute(
+            self._declare_sql(upsert),
+            {
+                "name": queue.name,
+                "state": queue.state.value,
+                "concurrency": queue.concurrency,
+                "tags": list(queue.tags),
+                "executor": queue.executor,
+                "executor_options": Json(queue.executor_options),
+                "polling_interval": queue.polling_interval,
+                "rate_limit": queue.rate_limit,
+                "rate_limit_window": queue.rate_limit_window,
+                "resume_at": queue.resume_at,
+            },
+        )
+
+        result = cursor.fetchone()
         return Queue(
             **{
                 **result,
@@ -662,6 +737,23 @@ class Chancy:
             async with conn.cursor(row_factory=dict_row) as cursor:
                 await cursor.execute(self._get_job_sql(), [ref.identifier])
                 record = await cursor.fetchone()
+                if record is None:
+                    return None
+                return QueuedJob.unpack(record)
+
+    @_ensure_sync_pool_is_open
+    def sync_get_job(self, ref: Reference) -> QueuedJob | None:
+        """
+        Synchronously resolve a reference to a job instance.
+
+        If the job no longer exists, returns ``None``.
+
+        :param ref: The reference to the job to retrieve.
+        """
+        with self.sync_pool.connection() as conn:
+            with conn.cursor(row_factory=dict_row) as cursor:
+                cursor.execute(self._get_job_sql(), [ref.identifier])
+                record = cursor.fetchone()
                 if record is None:
                     return None
                 return QueuedJob.unpack(record)

--- a/chancy/app.py
+++ b/chancy/app.py
@@ -256,6 +256,7 @@ class Chancy:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.pool.close()
+        del self.pool
 
     def __enter__(self):
         self.sync_pool.open()
@@ -263,6 +264,7 @@ class Chancy:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.sync_pool.close()
+        del self.sync_pool
         return False
 
     @cached_property

--- a/chancy/executors/base.py
+++ b/chancy/executors/base.py
@@ -213,6 +213,13 @@ class Executor(abc.ABC):
         Get the number of jobs currently within the executor.
         """
 
+    def __repr__(self):
+        return (
+            f"<{self.__class__.__name__}"
+            f" worker={self.worker!r}"
+            f" queue={self.queue.name!r}>"
+        )
+
     async def __aenter__(self):
         return self
 

--- a/chancy/job.py
+++ b/chancy/job.py
@@ -204,6 +204,8 @@ class QueuedJob(Job):
 
     #: The unique identifier for this job instance.
     id: str
+    #: The time at which this job was created.
+    created_at: datetime
     #: The time at which this job was started, if it has been started.
     started_at: Optional[datetime] = None
     #: The time at which this job was completed, if it has been completed.
@@ -222,6 +224,7 @@ class QueuedJob(Job):
             func=data["func"],
             kwargs=data["kwargs"],
             priority=data["priority"],
+            created_at=data["created_at"],
             scheduled_at=data["scheduled_at"],
             started_at=data["started_at"],
             completed_at=data["completed_at"],

--- a/chancy/plugins/cron/__init__.py
+++ b/chancy/plugins/cron/__init__.py
@@ -5,7 +5,7 @@ from psycopg import sql
 from croniter import croniter
 from psycopg.rows import dict_row
 
-from chancy.plugin import Plugin, PluginScope
+from chancy.plugin import Plugin
 from chancy.worker import Worker
 from chancy.app import Chancy
 from chancy.job import Job, IsAJob

--- a/chancy/plugins/cron/__init__.py
+++ b/chancy/plugins/cron/__init__.py
@@ -53,15 +53,15 @@ class Cron(Plugin):
 
         import asyncio
         from chancy import Chancy, Worker, Queue, job
-        from chancy.plugins.pruner import Cron
+        from chancy.plugins.cron import Cron
 
         @job(queue="default")
         def hello_world():
             print("hello_world")
 
-        async with Chancy("postgresql://localhost/postgres", plugins=[Cron()]) as chancy:
-                Cron(),
-            ],
+        async with Chancy(
+            "postgresql://localhost/postgres",
+            plugins=[Cron()]
         ) as chancy:
             await Cron.schedule(
                 chancy,

--- a/chancy/plugins/cron/__init__.py
+++ b/chancy/plugins/cron/__init__.py
@@ -99,10 +99,6 @@ class Cron(Plugin):
         super().__init__()
         self.poll_interval = poll_interval
 
-    @classmethod
-    def get_scope(cls) -> PluginScope:
-        return PluginScope.WORKER
-
     async def run(self, worker: Worker, chancy: Chancy):
         table = sql.Identifier(f"{chancy.prefix}cron")
 

--- a/chancy/plugins/leadership.py
+++ b/chancy/plugins/leadership.py
@@ -69,10 +69,6 @@ class Leadership(Plugin):
     def get_identifier() -> str:
         return "chancy.leadership"
 
-    @classmethod
-    def get_scope(cls) -> PluginScope:
-        return PluginScope.WORKER
-
     def get_tables(self) -> list[str]:
         """Get the names of all tables this plugin is responsible for."""
         return ["leader"]
@@ -178,10 +174,6 @@ class ImmediateLeadership(Plugin):
     This plugin is only ever intended for testing purposes, and should not be
     used in a production environment.
     """
-
-    @classmethod
-    def get_scope(cls) -> PluginScope:
-        return PluginScope.WORKER
 
     @staticmethod
     def get_identifier() -> str:

--- a/chancy/plugins/leadership.py
+++ b/chancy/plugins/leadership.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone, timedelta
 from psycopg import sql
 from psycopg.rows import dict_row
 
-from chancy.plugin import Plugin, PluginScope
+from chancy.plugin import Plugin
 from chancy.app import Chancy
 from chancy.worker import Worker
 

--- a/chancy/plugins/metrics/metrics.py
+++ b/chancy/plugins/metrics/metrics.py
@@ -58,7 +58,13 @@ class Metrics(Plugin):
     Metrics are synchronized across workers, so each worker has access to the
     full set of metrics.
 
-    Example:
+    .. note::
+        This plugin is enabled by default, you only need to provide it in the
+        list of plugins to customize its arguments or if ``no_default_plugins``
+        is set to ``True``.
+
+    Enable the plugin by adding it to the list of plugins in the Chancy
+    constructor:
 
     .. code-block:: python
 

--- a/chancy/plugins/pruner.py
+++ b/chancy/plugins/pruner.py
@@ -11,6 +11,11 @@ from chancy.utils import timed_block
 class Pruner(Plugin):
     """
     A plugin that prunes stale data from the database.
+    
+    .. note::
+        This plugin is enabled by default, you only need to provide it in the
+        list of plugins to customize its arguments or if ``no_default_plugins``
+        is set to ``True``.
 
     .. code-block:: python
 

--- a/chancy/plugins/pruner.py
+++ b/chancy/plugins/pruner.py
@@ -104,10 +104,6 @@ class Pruner(Plugin):
     def get_dependencies() -> list[str]:
         return ["chancy.leadership"]
 
-    @classmethod
-    def get_scope(cls) -> PluginScope:
-        return PluginScope.WORKER
-
     async def run(self, worker: Worker, chancy: Chancy):
         while await self.sleep(self.poll_interval):
             await self.wait_for_leader(worker)

--- a/chancy/plugins/pruner.py
+++ b/chancy/plugins/pruner.py
@@ -3,7 +3,7 @@ from psycopg.rows import DictRow, dict_row
 
 from chancy.app import Chancy
 from chancy.worker import Worker
-from chancy.plugin import Plugin, PluginScope
+from chancy.plugin import Plugin
 from chancy.rule import SQLAble, JobRules
 from chancy.utils import timed_block
 

--- a/chancy/plugins/pruner.py
+++ b/chancy/plugins/pruner.py
@@ -11,7 +11,7 @@ from chancy.utils import timed_block
 class Pruner(Plugin):
     """
     A plugin that prunes stale data from the database.
-    
+
     .. note::
         This plugin is enabled by default, you only need to provide it in the
         list of plugins to customize its arguments or if ``no_default_plugins``

--- a/chancy/plugins/recovery.py
+++ b/chancy/plugins/recovery.py
@@ -11,6 +11,20 @@ class Recovery(Plugin):
     """
     Recovers jobs that appear to be abandoned by a worker.
 
+    .. note::
+        This plugin is enabled by default, you only need to provide it in the
+        list of plugins to customize its arguments or if ``no_default_plugins``
+        is set to ``True``.
+
+    .. code-block:: python
+
+        from chancy.plugins.recovery import Recovery
+
+        async with Chancy(..., plugins=[
+            Recovery()
+        ]) as chancy:
+            ...
+
     Typically, this happens when a worker is unexpectedly terminated, or has
     otherwise been lost which we recognize by checking the last seen timestamp
     of the worker heartbeat.

--- a/chancy/plugins/reprioritize.py
+++ b/chancy/plugins/reprioritize.py
@@ -11,18 +11,18 @@ class Reprioritize(Plugin):
     in the queue. This helps prevent job starvation by gradually increasing the
     priority of older jobs.
 
-    Example usage:
-
     .. code-block:: python
 
-        plugin = Reprioritize(
-            rule=(
-                (Reprioritize.Rules.Age() > 600) &
-                (Reprioritize.Rules.Queue() == "high-priority")
-            ),
-            check_interval=300,
-            priority_increase=1
-        )
+        async with Chancy(..., plugins=[
+            Reprioritize(
+                rule=(
+                    Reprioritize.Rules.Age() > 600) &
+                    (Reprioritize.Rules.Queue() == "high-priority")
+                ),
+                check_interval=300,
+                priority_increase=1,
+        ]) as chancy:
+            ...
 
     This means that any job that has been in the queue for more than 10 minutes
     will have its priority increased by 1 every 5 minutes, but only for jobs

--- a/chancy/plugins/workflow/__init__.py
+++ b/chancy/plugins/workflow/__init__.py
@@ -151,6 +151,11 @@ class WorkflowPlugin(Plugin):
     you can use all the existing job features, such as job retries, timeouts,
     scheduling, and so on.
 
+    .. note::
+        This plugin is enabled by default, you only need to provide it in the
+        list of plugins to customize its arguments or if ``no_default_plugins``
+        is set to ``True``.
+
     Enable the plugin by adding it to the list of plugins in the Chancy
     constructor:
 
@@ -161,7 +166,7 @@ class WorkflowPlugin(Plugin):
 
         async with Chancy(
             "postgresql://localhost/postgres",
-            plugins=[Leadership(), WorkflowPlugin()]
+            plugins=[WorkflowPlugin()],
         ) as chancy:
             ...
 

--- a/chancy/utils.py
+++ b/chancy/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import enum
+import importlib
 import inspect
 import uuid
 import time
@@ -116,8 +117,8 @@ def import_string(name):
     :return: Any
     """
     mod_name, _, func_name = name.rpartition(".")
-    mod = __import__(mod_name, fromlist=[func_name])
-    return getattr(mod, func_name)
+    module = importlib.import_module(mod_name)
+    return getattr(module, func_name)
 
 
 def chancy_uuid() -> str:

--- a/chancy/utils.py
+++ b/chancy/utils.py
@@ -133,8 +133,8 @@ def chancy_uuid() -> str:
     """
     t = (time.time_ns() // 100) & 0xFFFFFFFFFFFFFF
     rand = secrets.randbits(62)
-    uuid = (t << 68) | (7 << 64) | (2 << 62) | rand
-    return f"{uuid:032x}"
+    uuid7 = (t << 68) | (7 << 64) | (2 << 62) | rand
+    return f"{uuid7:032x}"
 
 
 def json_dumps(obj, **kwargs):

--- a/chancy/worker.py
+++ b/chancy/worker.py
@@ -430,6 +430,14 @@ class Worker:
                         else:
                             maximum_jobs_to_poll = concurrency - len(executor)
                             if maximum_jobs_to_poll <= 0:
+                                await self.hub.emit(
+                                    "worker.queue.full",
+                                    {
+                                        "queue": queue,
+                                        "executor": executor,
+                                        "worker": self,
+                                    },
+                                )
                                 continue
 
                             async with self.chancy.pool.connection() as conn:

--- a/chancy/worker.py
+++ b/chancy/worker.py
@@ -738,7 +738,7 @@ class Worker:
                                 (scheduled_at IS NULL OR scheduled_at <= NOW())
                             ORDER BY
                                 priority DESC,
-                                id DESC
+                                id ASC
                             LIMIT
                                 %(maximum_jobs_to_fetch)s
                             FOR UPDATE OF {jobs} SKIP LOCKED

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
-# A docker file that sets up postgres.
-version: '3.1'
-
+# A docker file that sets up postgres for the test suite
+# with extensive logging and auto_explain enabled.
 services:
   db:
     image: postgres

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chancy"
-version = "0.23.3"
+version = "0.24.0"
 description = "A simple and flexible job queue for Python"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -225,3 +225,17 @@ async def test_failing_job(chancy: Chancy, worker: Worker):
     ref = await chancy.push(Job.from_func(job_that_fails))
     j = await chancy.wait_for_job(ref, timeout=30)
     assert j.state == QueuedJob.State.FAILED
+
+
+@pytest.mark.asyncio
+async def test_sync_push(chancy: Chancy, worker: Worker):
+    """
+    Ensure that the synchronous push method works as expected (as well as
+    sync_declare).
+    """
+    with chancy:
+        chancy.sync_declare(Queue("low"))
+        ref = chancy.sync_push(job_to_run.job.with_queue("low"))
+
+    j = await chancy.wait_for_job(ref, timeout=30)
+    assert j.state == QueuedJob.State.SUCCEEDED

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -122,17 +122,11 @@ async def test_immediate_processing(chancy: Chancy, worker: Worker):
     notifications instead of waiting for the full polling interval.
     """
     # Create a queue with a long polling interval
-    await chancy.declare(
-        Queue(
-            "test_immediate",
-            polling_interval=10,
-            concurrency=1,
-        ),
-        upsert=True,
-    )
+    await chancy.declare(Queue("test_immediate", polling_interval=10))
 
     # Wait for queue to be registered with worker
-    await asyncio.sleep(0.5)
+    await worker.hub.wait_for("worker.queue.started")
+    await asyncio.sleep(5)
 
     job = await chancy.push(Job.from_func(job_to_run, queue="test_immediate"))
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -108,3 +108,38 @@ async def test_error_on_needed_migrations(chancy_just_app):
         async with chancy_just_app:
             async with Worker(chancy_just_app):
                 pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chancy",
+    [{"notifications": True}],
+    indirect=True,
+)
+async def test_immediate_processing(chancy: Chancy, worker: Worker):
+    """
+    Test that the worker processes jobs immediately when receiving queue.pushed
+    notifications instead of waiting for the full polling interval.
+    """
+    # Create a queue with a long polling interval
+    await chancy.declare(
+        Queue(
+            "test_immediate",
+            polling_interval=10,
+            concurrency=1,
+        ),
+        upsert=True,
+    )
+
+    # Wait for queue to be registered with worker
+    await asyncio.sleep(0.5)
+
+    job = await chancy.push(Job.from_func(job_to_run, queue="test_immediate"))
+
+    result = await chancy.wait_for_job(
+        job,
+        interval=0.5,
+        timeout=1,  # Short timeout since we expect immediate processing
+    )
+
+    assert result.state == QueuedJob.State.SUCCEEDED

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3,18 +3,21 @@ import asyncio
 
 import pytest
 
-from chancy import Worker, Chancy, Job, Queue, QueuedJob
+from chancy import Worker, Chancy, Queue, QueuedJob, job
 from chancy.errors import MigrationsNeededError
 
 
+@job()
 def job_to_run():
     return
 
 
+@job()
 def job_that_fails():
     raise ValueError("This job should fail.")
 
 
+@job()
 def job_that_sleeps():
     time.sleep(0.5)
     return
@@ -36,9 +39,7 @@ async def test_queue_update(chancy: Chancy, worker: Worker):
         upsert=True,
     )
 
-    ref1 = await chancy.push(
-        Job.from_func(job_that_sleeps, queue="test_update")
-    )
+    ref1 = await chancy.push(job_that_sleeps.job.with_queue("test_update"))
 
     await asyncio.sleep(0.5)
 
@@ -57,7 +58,7 @@ async def test_queue_update(chancy: Chancy, worker: Worker):
     assert job1.state == QueuedJob.State.SUCCEEDED
 
     # Push another job to the queue with the new configuration
-    ref2 = await chancy.push(Job.from_func(job_to_run, queue="test_update"))
+    ref2 = await chancy.push(job_to_run.job.with_queue("test_update"))
     job2 = await chancy.wait_for_job(ref2, timeout=10)
     assert job2.state == QueuedJob.State.SUCCEEDED
 
@@ -82,9 +83,9 @@ async def test_queue_removal(chancy: Chancy, worker: Worker):
     )
 
     # Push a job and let it complete
-    ref = await chancy.push(Job.from_func(job_to_run, queue="test_removal"))
-    job = await chancy.wait_for_job(ref, timeout=30)
-    assert job.state == QueuedJob.State.SUCCEEDED
+    ref = await chancy.push(job_to_run.job.with_queue("test_removal"))
+    j = await chancy.wait_for_job(ref, timeout=30)
+    assert j.state == QueuedJob.State.SUCCEEDED
 
     # Verify the executor exists
     assert "test_removal" in worker.executors
@@ -99,7 +100,7 @@ async def test_queue_removal(chancy: Chancy, worker: Worker):
 
 
 @pytest.mark.asyncio
-async def test_error_on_needed_migrations(chancy_just_app):
+async def test_error_on_needed_migrations(chancy_just_app: Chancy):
     """
     Test that an error is raised if there are migrations that need to be
     applied before starting the worker.
@@ -111,29 +112,21 @@ async def test_error_on_needed_migrations(chancy_just_app):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "chancy",
-    [{"notifications": True}],
-    indirect=True,
-)
 async def test_immediate_processing(chancy: Chancy, worker: Worker):
     """
     Test that the worker processes jobs immediately when receiving queue.pushed
     notifications instead of waiting for the full polling interval.
     """
-    # Create a queue with a long polling interval
-    await chancy.declare(Queue("test_immediate", polling_interval=10))
-
-    # Wait for queue to be registered with worker
+    await chancy.declare(Queue("test_immediate", polling_interval=60))
     await worker.hub.wait_for("worker.queue.started")
     await asyncio.sleep(5)
 
-    job = await chancy.push(Job.from_func(job_to_run, queue="test_immediate"))
+    j = await chancy.push(job_to_run.job.with_queue("test_immediate"))
 
     result = await chancy.wait_for_job(
-        job,
-        interval=0.5,
-        timeout=1,  # Short timeout since we expect immediate processing
+        j,
+        interval=1,
+        timeout=5,  # Short timeout since we expect immediate processing
     )
 
     assert result.state == QueuedJob.State.SUCCEEDED


### PR DESCRIPTION
0.24.0
------

📝 Documentation

- Correction to the cron plugin example (Thanks @PaulM5406)

🐛 Fixes

- Fix for `sync_push_many_ex` using index access for columns instead of key
  by @nico-deforge.
- Fixed a deprecated usage of `ConnectionPool()` with an implicit `open=True`.
- Fixed the `queue.pushed` event not waking up a worker waiting for jobs.

✨ Improvements

- Exposed the `created_at` field on a QueuedJob record by @PaulM5406.
- Erase the cached psycopg pool connection when the context manager is closed
  to support multiple connects and disconnects.
- Added `Chancy.sync_declare()`, `Chancy.sync_declare_ex()` and
  `Chancy.sync_get_job`.
- Jobs are now naturally fetched oldest to newest due to the nature of the
  UUID7s that are used for the job IDs. Job features like priority may affect
  this ordering.
- Added the `worker.queue.full` event to notify when a queue's polling event
  ran, but was unable to start any jobs due to the executor being full.
- If a queue pulled its maximum number of jobs, it'll immediately re-poll for
  more, as it's unlikely that the queue is now empty.
