### PR TITLE
Remove on_worker_started from Plugin base ABC class

### DIFF
--- a/chancy/plugin.py
+++ b/chancy/plugin.py
@@ -130,11 +130,6 @@ class Plugin(abc.ABC):
         string for the plugin.
         """
 
-    async def on_worker_started(self, worker: "Worker"):
-        """
-        Called when the worker has started.
-        """
-
     async def on_job_starting(
         self,
         *,


### PR DESCRIPTION
Hey again,

Remove `Plugin.on_worker_started` as it is not called anywhere and I think this is replaced with events.

Thanks !