### PR TITLE
v0.25.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
         os: ["ubuntu-24.04", "macos-14", "windows-2022"]
-        pg: ["14", "15", "16", "17"]
+        pg: ["14", "15", "16", "17", "18"]
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       matrix:
         python-version: ["3.11", "3.14"]
         os: ["ubuntu-24.04", "macos-14", "windows-2022"]
-        pg: ["14", 18"]
+        pg: ["14", "18"]
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.6
 
-      - uses: ikalnytskyi/action-setup-postgres@v7
+      - uses: ikalnytskyi/action-setup-postgres@v8
         with:
           username: postgres
           password: localtest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4.1.6
 
     - name: Set up Python
-      uses: actions/setup-python@v5.1.0
+      uses: actions/setup-python@v6.0.0
       with:
         python-version: "3.13"
 
@@ -66,9 +66,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.14"]
         os: ["ubuntu-24.04", "macos-14", "windows-2022"]
-        pg: ["14", "15", "16", "17", "18"]
+        pg: ["14", 18"]
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
@@ -86,7 +86,7 @@ jobs:
         id: postgres
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -98,7 +98,7 @@ jobs:
 
       - name: Running tests
         run: |
-          uv run pytest -s -vvvvv --cov=chancy --cov-report=xml
+          uv run pytest -s -v --cov=chancy --cov-report=xml
 
       - name: Uploading coverage
         uses: codecov/codecov-action@v4
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v4.1.6
 
       - name: Set up Python
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v6.0.0
         with:
           python-version: "3.13"
 
@@ -158,7 +158,7 @@ jobs:
           path: dist
 
       - name: Set up Python
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v6.0.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,10 @@ jobs:
       run: npm run build
 
     - name: Checking for code smells
-      run: uvx ruff check
+      run: uv run ruff check
 
     - name: Checking for formatting issues
-      run: uvx ruff format --check
+      run: uv run ruff format --check
 
     - name: Build package
       run: uv build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.14.2
+  hooks:
+    - id: ruff-check
+      args: [ --fix ]
+    - id: ruff-format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog
 
 - Ensure `fetch_workflows_ex` always has guaranteed deterministic ordering of
   the returned workflow steps.
+- Workflow's now validate before pushing, ensuring workflows with circular
+  dependencies or invalid dependencies cannot be created.
 
 🐛 Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 0.25.1
 ------
 
+✨ Improvements
+
+- Ensure `fetch_workflows_ex` always has guaranteed deterministic ordering of
+  the returned workflow steps.
+
 🐛 Fixes
 
 - Fix a workflow's on_single_step_completed potentially running after the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Changelog
   dependencies or invalid dependencies cannot be created.
 - Test against PostgreSQL 18 and Python 3.14.
 - The metrics plugin now tracks metrics on its own operations.
+- Added `Chancy.purge_jobs()` and `Chancy.retry_jobs()` to bulk purge or
+  retry specific jobs by reference.
+- Added `_ex` versions of `purge_jobs`, `retry_jobs`, `pause_queue`,
+  `resume_queue`, `delete_queue`, and `cancel_job` to allow passing in a
+  cursor for transactional operations.
 
 🐛 Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog
 - Workflow's now validate before pushing, ensuring workflows with circular
   dependencies or invalid dependencies cannot be created.
 - Test against PostgreSQL 18 and Python 3.14.
+- The metrics plugin now tracks metrics on its own operations.
 
 🐛 Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog
   the returned workflow steps.
 - Workflow's now validate before pushing, ensuring workflows with circular
   dependencies or invalid dependencies cannot be created.
+- Test against PostgreSQL 18 and Python 3.14.
 
 🐛 Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+0.25.1
+------
+
+🐛 Fixes
+
+- Fix a workflow's on_single_step_completed potentially running after the
+  worker has lost leadership. Due to the workflow lock, this could not have
+  resulted in duplicate work.
+
 0.25.0
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog
 
 ✨ Improvements
 
+- Added the Trigger plugin, which allows you to start jobs when arbitrary
+  database events occur, such as inserts, updates, or deletes.
 - Ensure `fetch_workflows_ex` always has guaranteed deterministic ordering of
   the returned workflow steps.
 - Workflow's now validate before pushing, ensuring workflows with circular

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Postgres.
 ![PyPI Version](https://img.shields.io/pypi/v/chancy)
 ![Python Version](https://img.shields.io/pypi/pyversions/chancy)
 ![OS Platforms](https://img.shields.io/badge/OS-Linux%20|%20macOS%20|%20Windows-blue)
-![PostgreSQL Versions](https://img.shields.io/badge/PostgreSQL-%2014%20|%2015%20|%2016%20|%2017-blue)
+![PostgreSQL Versions](https://img.shields.io/badge/PostgreSQL-%2014%20|%2015%20|%2016%20|%2017%20|%2018-blue)
 
 ## Key Features
 

--- a/chancy/app.py
+++ b/chancy/app.py
@@ -888,6 +888,7 @@ class Chancy:
                     raise KeyError(f"Queue {name!r} not found.")
                 return Queue.unpack(record)
 
+    @_ensure_pool_is_open
     async def delete_queue(self, name: str, *, purge_jobs: bool = True):
         """
         Delete a queue by name.
@@ -902,26 +903,9 @@ class Chancy:
         """
         async with self.pool.connection() as conn:
             async with conn.cursor(row_factory=dict_row) as cursor:
-                await cursor.execute(
-                    sql.SQL(
-                        """
-                        DELETE FROM {queues}
-                        WHERE name = %s
-                        """
-                    ).format(queues=sql.Identifier(f"{self.prefix}queues")),
-                    [name],
-                )
-                if purge_jobs:
-                    await cursor.execute(
-                        sql.SQL(
-                            """
-                            DELETE FROM {jobs}
-                            WHERE queue = %s
-                            """
-                        ).format(jobs=sql.Identifier(f"{self.prefix}jobs")),
-                        [name],
-                    )
+                await self.delete_queue_ex(cursor, name, purge_jobs=purge_jobs)
 
+    @_ensure_pool_is_open
     async def pause_queue(
         self,
         name: str,
@@ -944,24 +928,16 @@ class Chancy:
         """
         async with self.pool.connection() as conn:
             async with conn.cursor(row_factory=dict_row) as cursor:
+                # Normalize timedelta to absolute datetime if needed
                 if isinstance(resume_at, datetime.timedelta):
                     resume_at = (
                         datetime.datetime.now(tz=datetime.timezone.utc)
                         + resume_at
                     )
-
-                await cursor.execute(
-                    sql.SQL(
-                        """
-                        UPDATE {queues}
-                        SET state = 'paused', resume_at = %(resume_at)s
-                        WHERE name = %(name)s
-                        """
-                    ).format(queues=sql.Identifier(f"{self.prefix}queues")),
-                    {"name": name, "resume_at": resume_at},
-                )
+                await self.pause_queue_ex(cursor, name, resume_at=resume_at)
                 await self.notify(cursor, "queue.paused", {"q": name})
 
+    @_ensure_pool_is_open
     async def resume_queue(self, name: str):
         """
         Resume a queue by name.
@@ -976,19 +952,120 @@ class Chancy:
         """
         async with self.pool.connection() as conn:
             async with conn.cursor(row_factory=dict_row) as cursor:
-                await cursor.execute(
-                    sql.SQL(
-                        """
-                        UPDATE {queues}
-                        SET
-                            state = 'active',
-                            resume_at = NULL
-                        WHERE name = %(name)s
-                        """
-                    ).format(queues=sql.Identifier(f"{self.prefix}queues")),
-                    {"name": name},
-                )
+                await self.resume_queue_ex(cursor, name)
                 await self.notify(cursor, "queue.resumed", {"q": name})
+
+    async def delete_queue_ex(
+        self,
+        cursor: AsyncCursor[DictRow],
+        name: str,
+        *,
+        purge_jobs: bool = True,
+    ) -> int:
+        """
+        Delete a queue by name using an existing cursor.
+
+        See :meth:`delete_queue` for more information.
+
+        .. seealso::
+
+            :meth:`delete_queue` for a helper that manages the connection and
+            transaction.
+
+        :param cursor: The cursor to use for the operation. Must use a
+            dict_row row factory.
+        :param name: The name of the queue to delete.
+        :param purge_jobs: If ``True``, delete all jobs in the queue as well.
+        :return: The number of queues deleted (0 or 1).
+        """
+        await cursor.execute(
+            sql.SQL(
+                """
+                DELETE FROM {queues}
+                WHERE name = %s
+                """
+            ).format(queues=sql.Identifier(f"{self.prefix}queues")),
+            [name],
+        )
+        if purge_jobs:
+            await cursor.execute(
+                sql.SQL(
+                    """
+                    DELETE FROM {jobs}
+                    WHERE queue = %s
+                    """
+                ).format(jobs=sql.Identifier(f"{self.prefix}jobs")),
+                [name],
+            )
+        return cursor.rowcount or 0
+
+    async def pause_queue_ex(
+        self,
+        cursor: AsyncCursor[DictRow],
+        name: str,
+        *,
+        resume_at: datetime.datetime | None = None,
+    ) -> int:
+        """
+        Pause a queue by name using an existing cursor.
+
+        See :meth:`pause_queue` for more information.
+
+        .. seealso::
+
+            :meth:`pause_queue` for a helper that manages the connection and
+            emits notifications.
+
+        :param cursor: The cursor to use for the operation. Must use a
+            dict_row row factory.
+        :param name: The name of the queue to pause.
+        :param resume_at: An absolute datetime when the queue should
+            automatically resume, or ``None`` to require manual resume.
+        :return: The number of rows updated.
+        """
+        await cursor.execute(
+            sql.SQL(
+                """
+                UPDATE {queues}
+                SET state = 'paused', resume_at = %(resume_at)s
+                WHERE name = %(name)s
+                """
+            ).format(queues=sql.Identifier(f"{self.prefix}queues")),
+            {"name": name, "resume_at": resume_at},
+        )
+        return cursor.rowcount or 0
+
+    async def resume_queue_ex(
+        self, cursor: AsyncCursor[DictRow], name: str
+    ) -> int:
+        """
+        Resume a queue by name using an existing cursor.
+
+        See :meth:`resume_queue` for more information.
+
+        .. seealso::
+
+            :meth:`resume_queue` for a helper that manages the connection and
+            emits notifications.
+
+        :param cursor: The cursor to use for the operation. Must use a
+            dict_row row factory.
+        :param name: The name of the queue to resume.
+        :return: The number of rows updated.
+        """
+        await cursor.execute(
+            sql.SQL(
+                """
+                UPDATE {queues}
+                SET
+                    state = 'active',
+                    resume_at = NULL
+                WHERE name = %(name)s
+                """
+            ).format(queues=sql.Identifier(f"{self.prefix}queues")),
+            {"name": name},
+        )
+        return cursor.rowcount or 0
 
     @_ensure_pool_is_open
     async def get_all_workers(self) -> list[dict[str, Any]]:
@@ -1060,22 +1137,43 @@ class Chancy:
         async with self.pool.connection() as conn:
             async with conn.cursor(row_factory=dict_row) as cursor:
                 async with conn.transaction():
-                    await cursor.execute(
-                        sql.SQL(
-                            """
-                            UPDATE {jobs}
-                            SET state = 'failed'
-                            WHERE id = %s
-                            """
-                        ).format(jobs=sql.Identifier(f"{self.prefix}jobs")),
-                        [ref.identifier],
-                    )
+                    await self.cancel_job_ex(cursor, ref)
 
                     # Tell any workers that might have already snagged the job
                     # to cancel it.
                     await self.notify(
                         cursor, "job.cancelled", {"j": ref.identifier}
                     )
+
+    async def cancel_job_ex(
+        self, cursor: AsyncCursor[DictRow], ref: Reference
+    ) -> int:
+        """
+        Cancel a job by reference using an existing cursor.
+
+        See :meth:`cancel_job` for more information.
+
+        .. seealso::
+
+            :meth:`cancel_job` for a helper that manages the connection,
+            transaction, and emits notifications.
+
+        :param cursor: The cursor to use for the operation. Must use a
+            dict_row row factory.
+        :param ref: The reference to the job to cancel.
+        :return: The number of rows updated (0 or 1).
+        """
+        await cursor.execute(
+            sql.SQL(
+                """
+                UPDATE {jobs}
+                SET state = 'failed'
+                WHERE id = %s
+                """
+            ).format(jobs=sql.Identifier(f"{self.prefix}jobs")),
+            [ref.identifier],
+        )
+        return cursor.rowcount or 0
 
     def _get_all_workers_sql(self):
         return sql.SQL(
@@ -1092,6 +1190,124 @@ class Chancy:
             workers=sql.Identifier(f"{self.prefix}workers"),
             leader=sql.Identifier(f"{self.prefix}leader"),
         )
+
+    @_ensure_pool_is_open
+    async def retry_jobs(self, refs: list[Reference]):
+        """
+        Retry one or more jobs by reference.
+
+        This will make the referenced jobs eligible to be picked up again by
+        workers by resetting transient execution fields and scheduling them
+        immediately. Attempts are reset to 0 to permit re-execution even if the
+        job had reached ``max_attempts``. Error history is preserved.
+
+        Jobs currently in the ``running`` state are ignored.
+
+        :param refs: The references to the jobs to retry.
+        """
+        if not refs:
+            return
+
+        async with self.pool.connection() as conn:
+            async with conn.cursor(row_factory=dict_row) as cursor:
+                async with conn.transaction():
+                    queues = await self.retry_jobs_ex(cursor, refs)
+                    if self.notifications and queues:
+                        for q in queues:
+                            await self.notify(cursor, "queue.pushed", {"q": q})
+
+    @_ensure_pool_is_open
+    async def purge_jobs(self, refs: list[Reference]):
+        """
+        Permanently remove one or more jobs by reference.
+
+        This will delete the job rows from the database. Use with care. It will
+        not handle cancellation of running jobs; use :meth:`cancel_job` for
+        that.
+
+        :param refs: The references to the jobs to purge.
+        """
+        if not refs:
+            return
+
+        async with self.pool.connection() as conn:
+            async with conn.cursor(row_factory=dict_row) as cursor:
+                await self.purge_jobs_ex(cursor, refs)
+
+    async def retry_jobs_ex(
+        self, cursor: AsyncCursor[DictRow], refs: list[Reference]
+    ) -> set[str]:
+        """
+        Retry one or more jobs by reference using an existing cursor.
+
+        See :meth:`retry_jobs` for more information.
+
+        .. seealso::
+
+            :meth:`retry_jobs` for a helper that manages the connection and
+            emits notifications.
+
+        :param cursor: The cursor to use for the operation. Must use a
+            dict_row row factory.
+        :param refs: The references to the jobs to retry.
+        :return: The set of affected queue names to assist callers in
+            emitting notifications.
+        """
+        if not refs:
+            return set()
+
+        await cursor.execute(
+            sql.SQL(
+                """
+                UPDATE {jobs} AS j
+                SET
+                    started_at = NULL,
+                    completed_at = NULL,
+                    taken_by = NULL,
+                    scheduled_at = NOW(),
+                    state = 'retrying',
+                    attempts = 0
+                WHERE j.id = ANY(%(ids)s)
+                  AND j.state != 'running'
+                RETURNING j.queue
+                """
+            ).format(jobs=sql.Identifier(f"{self.prefix}jobs")),
+            {"ids": [ref.identifier for ref in refs]},
+        )
+        rows = await cursor.fetchall()
+        return {row["queue"] for row in rows}
+
+    async def purge_jobs_ex(
+        self, cursor: AsyncCursor[DictRow], refs: list[Reference]
+    ) -> int:
+        """
+        Permanently remove one or more jobs by reference using an existing
+        cursor.
+
+        See :meth:`purge_jobs` for more information.
+
+        .. seealso::
+
+            :meth:`purge_jobs` for a helper that manages the connection.
+
+        :param cursor: The cursor to use for the operation. Must use a
+            dict_row row factory.
+        :param refs: The references to the jobs to purge.
+        :return: The number of rows deleted.
+        """
+        if not refs:
+            return 0
+
+        await cursor.execute(
+            sql.SQL(
+                """
+                DELETE FROM {jobs}
+                WHERE id = ANY(%(ids)s)
+                """
+            ).format(jobs=sql.Identifier(f"{self.prefix}jobs")),
+            {"ids": [ref.identifier for ref in refs]},
+        )
+        return cursor.rowcount or 0
 
     def _get_queue_sql(self):
         return sql.SQL(

--- a/chancy/plugins/__init__.py
+++ b/chancy/plugins/__init__.py
@@ -45,5 +45,8 @@ and typically require additional dependencies:
   the priority of jobs based on how long they've been in the queue.
 - :class:`chancy.plugins.sentry.SentryPlugin`: This plugin sends job exceptions
   to Sentry, along with metadata about the job and worker.
+- :class:`chancy.plugins.trigger.Trigger`: This plugin allows jobs to be queued
+  based on database triggers, such as rows being inserted/deleted/updated to a
+  table.
 
 """

--- a/chancy/plugins/api/ui/vite.config.ts
+++ b/chancy/plugins/api/ui/vite.config.ts
@@ -10,5 +10,10 @@ export default defineConfig({
     // Since our dist directory is outside the vite root,
     // it doesn't empty by default.
     emptyOutDir: true,
+  },
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
   }
 })

--- a/chancy/plugins/metrics/metrics.py
+++ b/chancy/plugins/metrics/metrics.py
@@ -17,6 +17,7 @@ from chancy.app import Chancy
 from chancy.job import QueuedJob
 from chancy.plugin import Plugin
 from chancy.worker import Worker
+from chancy.utils import timed_block
 
 Resolution = Literal["1min", "5min", "1hour", "1day"]
 MetricValue = Union[int, float, Dict[str, Union[int, float]]]
@@ -131,6 +132,8 @@ class Metrics(Plugin):
 
         # Track metrics that have been modified locally since last sync.
         self.modified_metrics: Set[str] = set()
+        # Protect access to modified_metrics to avoid races with sync.
+        self.modified_lock: asyncio.Lock = asyncio.Lock()
 
         # Last sync timestamp.
         self.last_sync_time = datetime.datetime.now(datetime.timezone.utc)
@@ -272,7 +275,8 @@ class Metrics(Plugin):
                 if len(points) > self.max_points[resolution]:
                     points.pop()
 
-                self.modified_metrics.add(metric_key)
+                async with self.modified_lock:
+                    self.modified_metrics.add(metric_key)
 
     async def record_gauge(
         self, metric_key: str, value: Union[int, float]
@@ -317,7 +321,8 @@ class Metrics(Plugin):
                 if len(points) > self.max_points[resolution]:
                     points.pop()
 
-                self.modified_metrics.add(metric_key)
+                async with self.modified_lock:
+                    self.modified_metrics.add(metric_key)
 
     async def record_histogram_value(
         self, metric_key: str, value: Union[int, float]
@@ -392,38 +397,90 @@ class Metrics(Plugin):
                 if len(points) > self.max_points[resolution]:
                     points.pop()
 
-                self.modified_metrics.add(metric_key)
+                async with self.modified_lock:
+                    self.modified_metrics.add(metric_key)
 
     async def _sync_metrics(self, chancy: Chancy) -> None:
         """
         Synchronize metrics with the database and other workers.
+        Records health metrics and avoids dropping updates occurring during sync.
         """
-        if self.modified_metrics:
-            await self._push_metrics_to_db(chancy)
+        # Snapshot the modified set up-front to prevent losing updates recorded
+        # during this method.
+        async with self.modified_lock:
+            to_push = set(self.modified_metrics)
+            self.modified_metrics.clear()
 
-        self.aggregated_metrics_cache.update(
-            await self._get_raw_metrics(chancy)
+        with timed_block() as t_sync:
+            if to_push:
+                try:
+                    await self._push_metrics_to_db(chancy, metric_keys=to_push)
+                except Exception:
+                    await self.increment_counter("metrics:sync_errors", 1)
+                    raise
+
+            with timed_block() as t_pull:
+                try:
+                    aggregated = await self._get_raw_metrics(chancy)
+                except Exception:
+                    await self.increment_counter("metrics:sync_errors", 1)
+                    raise
+
+            self.aggregated_metrics_cache.update(aggregated)
+            self.last_sync_time = datetime.datetime.now(datetime.timezone.utc)
+
+        await self.increment_counter("metrics:sync_count", 1)
+        await self.record_histogram_value(
+            "metrics:sync_duration_s", t_sync.elapsed
         )
-        self.last_sync_time = datetime.datetime.now(datetime.timezone.utc)
-        self.modified_metrics.clear()
+        await self.record_histogram_value(
+            "metrics:db_pull_duration_s", t_pull.elapsed
+        )
+        await self.record_gauge(
+            "metrics:local_cache_size", len(self.local_metrics_cache)
+        )
+        await self.record_gauge(
+            "metrics:aggregated_cache_size",
+            len(self.aggregated_metrics_cache),
+        )
+        await self.record_gauge(
+            "metrics:last_sync_s", self.last_sync_time.timestamp()
+        )
 
-    async def _push_metrics_to_db(self, chancy: Chancy) -> None:
+        async with self.modified_lock:
+            to_push_health = set(self.modified_metrics)
+            self.modified_metrics.clear()
+        if to_push_health:
+            try:
+                await self._push_metrics_to_db(
+                    chancy, metric_keys=to_push_health
+                )
+            except Exception:
+                await self.increment_counter("metrics:sync_errors", 1)
+                raise
+
+    async def _push_metrics_to_db(
+        self, chancy: Chancy, *, metric_keys: Set[str] | None = None
+    ) -> None:
         """
         Push modified metrics to the database.
 
         Only pushes metrics from the local_metrics_cache, not the aggregated
         cache.
         """
-        if not self.modified_metrics:
+        metric_keys = metric_keys or self.modified_metrics
+        if not metric_keys:
             return
 
         metrics_to_insert = []
 
-        for metric_key in self.modified_metrics:
+        for metric_key in metric_keys:
             if metric_key not in self.local_metrics_cache:
                 continue
 
-            metric = self.local_metrics_cache[metric_key]
+            # Copy points under the per-metric lock to avoid races with writers.
+            async with await self._get_metric_lock(metric_key):
+                metric = self.local_metrics_cache[metric_key]
 
             for resolution in self.max_points.keys():
                 if resolution == "1min":
@@ -595,38 +652,47 @@ class Metrics(Plugin):
                 f"{chancy.prefix}{table}" for table in all_tables
             ]
 
-            async with chancy.pool.connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cursor:
-                    query = sql.SQL(
-                        """
-                        SELECT
-                            table_name,
-                            pg_total_relation_size(table_name) as total_size_bytes,
-                            pg_relation_size(table_name) as table_size_bytes,
-                            pg_indexes_size(table_name) as index_size_bytes
-                        FROM unnest({tables}::text[]) AS table_name
-                    """
-                    ).format(tables=sql.Literal(prefixed_tables))
+            with timed_block() as t_sizes:
+                try:
+                    async with chancy.pool.connection() as conn:
+                        async with conn.cursor(row_factory=dict_row) as cursor:
+                            query = sql.SQL(
+                                """
+                                SELECT
+                                    table_name,
+                                    pg_total_relation_size(table_name) as total_size_bytes,
+                                    pg_relation_size(table_name) as table_size_bytes,
+                                    pg_indexes_size(table_name) as index_size_bytes
+                                FROM unnest({tables}::text[]) AS table_name
+                                """
+                            ).format(tables=sql.Literal(prefixed_tables))
 
-                    await cursor.execute(query)
+                            await cursor.execute(query)
 
-                    async for result in cursor:
-                        table_name = result["table_name"].removeprefix(
-                            chancy.prefix
-                        )
+                            async for result in cursor:
+                                table_name = result["table_name"].removeprefix(
+                                    chancy.prefix
+                                )
 
-                        await self.record_histogram_value(
-                            f"table:{table_name}:total_size_bytes",
-                            result["total_size_bytes"],
-                        )
-                        await self.record_histogram_value(
-                            f"table:{table_name}:table_size_bytes",
-                            result["table_size_bytes"],
-                        )
-                        await self.record_histogram_value(
-                            f"table:{table_name}:index_size_bytes",
-                            result["index_size_bytes"],
-                        )
+                                await self.record_histogram_value(
+                                    f"table:{table_name}:total_size_bytes",
+                                    result["total_size_bytes"],
+                                )
+                                await self.record_histogram_value(
+                                    f"table:{table_name}:table_size_bytes",
+                                    result["table_size_bytes"],
+                                )
+                                await self.record_histogram_value(
+                                    f"table:{table_name}:index_size_bytes",
+                                    result["index_size_bytes"],
+                                )
+                except Exception:
+                    await self.increment_counter("metrics:table_size_errors", 1)
+                finally:
+                    await self.increment_counter("metrics:table_size_runs", 1)
+                    await self.record_histogram_value(
+                        "metrics:table_size_duration_s", t_sizes.elapsed
+                    )
 
     async def _get_raw_metrics(
         self,

--- a/chancy/plugins/trigger/__init__.py
+++ b/chancy/plugins/trigger/__init__.py
@@ -1,0 +1,711 @@
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+from uuid import UUID
+
+from psycopg import sql, AsyncCursor
+from psycopg.rows import dict_row, DictRow
+
+from chancy.plugin import Plugin
+from chancy.app import Chancy
+from chancy.job import Job, IsAJob
+
+
+@dataclass
+class TriggerConfig:
+    """Configuration for a registered trigger."""
+
+    id: UUID
+    table_name: str
+    schema_name: str
+    trigger_name: str
+    operations: List[str]
+    job_template: Job
+    enabled: bool
+    created_at: datetime
+
+
+class Trigger(Plugin):
+    """
+    Install database triggers on non-Chancy tables that create jobs when rows
+    change.
+
+    The Trigger plugin allows you to automatically create jobs in response to
+    database changes on any table. It uses PostgreSQL statement-level triggers
+    for optimal performance with bulk operations. Since these triggers are run
+    by the database itself, jobs will always be created - even if all Chancy
+    workers are offline.
+
+    .. tip::
+
+        Database triggers should be avoided for extremely high-frequency
+        operations or tables with very high write volumes, as they can introduce
+        significant overhead.
+
+    Usage
+    -----
+
+    You can register a job to run when a specific table is modified by
+    creating a trigger. For example, to run a job whenever a row in the
+    ``users`` table is inserted or updated, you can do the following:
+
+    .. code-block:: python
+
+        from chancy import Chancy, Worker, Queue, job
+        from chancy.plugins.trigger import Trigger
+
+        @job(queue="user_events")
+        def process_user_change():
+            pass
+
+        async with Chancy(
+            "postgresql://localhost/postgres",
+            plugins=[Trigger()]
+        ) as chancy:
+            trigger_id = await Trigger.register_trigger(
+                chancy,
+                table_name="users",
+                operations=["INSERT", "UPDATE"],
+                job_template=process_user_change,
+            )
+
+    More information about what triggered the job can be found in the job's
+    metadata:
+
+    .. code-block:: python
+
+        from chancy import job, QueuedJob
+
+        @job(queue="user_events")
+        def process_user_change(*, context: QueuedJob):
+            print(context.meta["trigger"])
+
+    Would output something like:
+
+    .. code-block::
+
+        {
+            'operation': 'INSERT',
+            'timestamp': '2025-05-29T05:51:26.777476+00:00',
+            'table_name': 'test_users',
+            'schema_name': 'public',
+            'trigger_name': 'chancy_trigger_675ed409_4da2_4967_bfc7_7bc641f1cc92_insert'
+        }
+
+    The timestamp is particularly useful, as you can use it to select all
+    recently changed rows when combined with a timestamp column in the
+    table.
+    """
+
+    def migrate_key(self) -> str | None:
+        return "trigger"
+
+    def migrate_package(self) -> str | None:
+        return "chancy.plugins.trigger.migrations"
+
+    def get_tables(self) -> list[str]:
+        return ["triggers"]
+
+    @staticmethod
+    def get_identifier() -> str:
+        return "chancy.trigger"
+
+    @classmethod
+    async def register_trigger(
+        cls,
+        chancy: Chancy,
+        *,
+        table_name: str,
+        operations: List[str],
+        job_template: Job | IsAJob,
+        schema_name: str = "public",
+        enabled: bool = True,
+    ) -> UUID:
+        """
+        Register a database trigger that creates jobs when table rows change.
+
+        This method creates a PostgreSQL trigger on the specified table that will
+        automatically queue jobs when the specified DML operations occur. The trigger
+        is statement-level, meaning one job is created per SQL statement regardless
+        of how many rows are affected.
+
+        Example:
+            >>> from chancy import Chancy, job
+            >>> from chancy.plugins.trigger import Trigger
+            >>>
+            >>> @job(queue="events")
+            >>> def handle_user_change():
+            >>>     pass
+            >>>
+            >>> async with Chancy(..., plugins=[Trigger()]) as app:
+            >>>     trigger_id = await Trigger.register_trigger(
+            >>>         app,
+            >>>         table_name="users",
+            >>>         operations=["INSERT", "UPDATE"],
+            >>>         job_template=handle_user_change
+            >>>     )
+
+        :param chancy: The Chancy application instance.
+        :param table_name: Name of the table to monitor.
+        :param operations: List of operations to monitor. Must be one or more of:
+                          'INSERT', 'UPDATE', 'DELETE'. Case-insensitive.
+        :param job_template: Job template to create when trigger fires.
+        :param schema_name: Schema containing the table (default: 'public').
+        :param enabled: Whether the trigger should be enabled immediately (default: True).
+        :return: The unique trigger identifier (UUID).
+        :raises ValueError: If operations list is empty or contains invalid operations.
+        """
+        async with chancy.pool.connection() as conn:
+            async with conn.cursor(row_factory=dict_row) as cursor:
+                async with conn.transaction():
+                    return await cls.register_trigger_ex(
+                        cursor,
+                        chancy,
+                        table_name,
+                        operations,
+                        job_template,
+                        schema_name=schema_name,
+                        enabled=enabled,
+                    )
+
+    @classmethod
+    async def register_trigger_ex(
+        cls,
+        cursor: AsyncCursor[DictRow],
+        chancy: Chancy,
+        table_name: str,
+        operations: List[str],
+        job_template: Job | IsAJob,
+        *,
+        schema_name: str = "public",
+        enabled: bool = True,
+    ) -> UUID:
+        """
+        Register a database trigger (transaction-aware version).
+
+        This is a lower-level version of register_trigger that accepts an existing
+        cursor object, allowing it to be used within transactions.
+
+        :param cursor: The database cursor to use for the query.
+        :param chancy: The Chancy application instance.
+        :param table_name: Name of the table to monitor.
+        :param operations: List of operations to monitor ('INSERT', 'UPDATE', 'DELETE').
+        :param job_template: Job template to create when trigger fires.
+        :param schema_name: Schema containing the table (default: 'public').
+        :param enabled: Whether the trigger should be enabled immediately (default: True).
+        :return: The unique trigger identifier (UUID).
+        :raises ValueError: If operations list is empty or contains invalid operations.
+        """
+        if not operations:
+            raise ValueError("operations list cannot be empty")
+
+        valid_ops = {"INSERT", "UPDATE", "DELETE"}
+        for op in operations:
+            if op.upper() not in valid_ops:
+                raise ValueError(
+                    f"Invalid operation: {op}. Must be one of {valid_ops}"
+                )
+
+        operations = [op.upper() for op in operations]
+        job = (
+            job_template if isinstance(job_template, Job) else job_template.job
+        )
+
+        trigger_id = uuid.uuid4()
+        trigger_name = (
+            f"{chancy.prefix}trigger_{str(trigger_id).replace('-', '_')}"
+        )
+
+        await cls._ensure_trigger_function(cursor, chancy.prefix)
+        await cursor.execute(
+            sql.SQL("""
+                INSERT INTO {table} (
+                    id,
+                    table_name,
+                    schema_name,
+                    trigger_name,
+                    operations,
+                    job_template,
+                    enabled
+                ) VALUES (
+                    %(id)s,
+                    %(table_name)s,
+                    %(schema_name)s,
+                    %(trigger_name)s,
+                    %(operations)s,
+                    %(job_template)s,
+                    %(enabled)s
+                )
+            """).format(table=sql.Identifier(f"{chancy.prefix}triggers")),
+            {
+                "id": trigger_id,
+                "table_name": table_name,
+                "schema_name": schema_name,
+                "trigger_name": trigger_name,
+                "operations": json.dumps(operations),
+                "job_template": json.dumps(job.pack()),
+                "enabled": enabled,
+            },
+        )
+
+        if enabled:
+            await cls._create_database_triggers(
+                cursor,
+                schema_name,
+                table_name,
+                trigger_name,
+                operations,
+                chancy.prefix,
+            )
+
+        return trigger_id
+
+    @classmethod
+    async def unregister_trigger(
+        cls, chancy: Chancy, trigger_id: UUID | str
+    ) -> None:
+        """
+        Permanently remove a trigger.
+
+        This removes both the database triggers and the trigger configuration.
+        Once unregistered, the trigger cannot be re-enabled and must be
+        re-registered if needed again.
+
+        :param chancy: The Chancy application instance.
+        :param trigger_id: The unique trigger identifier to remove (UUID or string).
+        :raises ValueError: If the trigger_id does not exist.
+        """
+        async with chancy.pool.connection() as conn:
+            async with conn.cursor(row_factory=dict_row) as cursor:
+                async with conn.transaction():
+                    await cls.unregister_trigger_ex(cursor, chancy, trigger_id)
+
+    @classmethod
+    async def unregister_trigger_ex(
+        cls,
+        cursor: AsyncCursor[DictRow],
+        chancy: Chancy,
+        trigger_id: UUID | str,
+    ) -> None:
+        """
+        Permanently remove a trigger (transaction-aware version).
+
+        :param cursor: The database cursor to use for the query.
+        :param chancy: The Chancy application instance.
+        :param trigger_id: The unique trigger identifier to remove (UUID or string).
+        :raises ValueError: If the trigger_id does not exist.
+        """
+        if isinstance(trigger_id, str):
+            trigger_id = UUID(trigger_id)
+
+        table = sql.Identifier(f"{chancy.prefix}triggers")
+
+        # Get trigger info before deleting
+        await cursor.execute(
+            sql.SQL("""
+                SELECT
+                    schema_name,
+                    table_name,
+                    trigger_name,
+                    operations
+                FROM {table} WHERE id = %(id)s
+            """).format(table=table),
+            {"id": trigger_id},
+        )
+
+        row = await cursor.fetchone()
+        if not row:
+            raise ValueError(f"Trigger {trigger_id} not found")
+
+        for operation in row["operations"]:
+            trigger_name = f"{row['trigger_name']}_{operation.lower()}"
+            await cls._drop_database_trigger(
+                cursor,
+                row["schema_name"],
+                row["table_name"],
+                trigger_name,
+            )
+
+        # Remove from config table
+        await cursor.execute(
+            sql.SQL("DELETE FROM {table} WHERE id = %(id)s").format(
+                table=table
+            ),
+            {"id": trigger_id},
+        )
+
+    @classmethod
+    async def enable_trigger(
+        cls, chancy: Chancy, trigger_id: UUID | str
+    ) -> bool:
+        """
+        Enable a disabled trigger.
+
+        Re-creates the database triggers for a previously disabled trigger.
+        If the trigger is already enabled, this is a no-op.
+
+        :param chancy: The Chancy application instance.
+        :param trigger_id: The unique trigger identifier (UUID or string).
+        :return: True if the trigger was enabled, False if it was already enabled.
+        :raises ValueError: If the trigger_id does not exist.
+        """
+        async with chancy.pool.connection() as conn:
+            async with conn.cursor(row_factory=dict_row) as cursor:
+                async with conn.transaction():
+                    return await cls.enable_trigger_ex(
+                        cursor, chancy, trigger_id
+                    )
+
+    @classmethod
+    async def enable_trigger_ex(
+        cls,
+        cursor: AsyncCursor[DictRow],
+        chancy: Chancy,
+        trigger_id: UUID | str,
+    ) -> bool:
+        """
+        Enable a disabled trigger (transaction-aware version).
+
+        :param cursor: The database cursor to use for the query.
+        :param chancy: The Chancy application instance.
+        :param trigger_id: The unique trigger identifier (UUID or string).
+        :return: True if the trigger was enabled, False if it was already enabled.
+        :raises ValueError: If the trigger_id does not exist.
+        """
+        return await cls._toggle_trigger_ex(cursor, chancy, trigger_id, True)
+
+    @classmethod
+    async def disable_trigger(
+        cls, chancy: Chancy, trigger_id: UUID | str
+    ) -> bool:
+        """
+        Disable an enabled trigger.
+
+        Drops the database triggers but keeps the configuration, allowing the
+        trigger to be re-enabled later. If the trigger is already disabled,
+        this is a no-op.
+
+        :param chancy: The Chancy application instance.
+        :param trigger_id: The unique trigger identifier (UUID or string).
+        :return: True if the trigger was disabled, False if it was already disabled.
+        :raises ValueError: If the trigger_id does not exist.
+        """
+        async with chancy.pool.connection() as conn:
+            async with conn.cursor(row_factory=dict_row) as cursor:
+                async with conn.transaction():
+                    return await cls.disable_trigger_ex(
+                        cursor, chancy, trigger_id
+                    )
+
+    @classmethod
+    async def disable_trigger_ex(
+        cls,
+        cursor: AsyncCursor[DictRow],
+        chancy: Chancy,
+        trigger_id: UUID | str,
+    ) -> bool:
+        """
+        Disable an enabled trigger (transaction-aware version).
+
+        :param cursor: The database cursor to use for the query.
+        :param chancy: The Chancy application instance.
+        :param trigger_id: The unique trigger identifier (UUID or string).
+        :return: True if the trigger was disabled, False if it was already disabled.
+        :raises ValueError: If the trigger_id does not exist.
+        """
+        return await cls._toggle_trigger_ex(cursor, chancy, trigger_id, False)
+
+    @classmethod
+    async def _toggle_trigger_ex(
+        cls,
+        cursor: AsyncCursor[DictRow],
+        chancy: Chancy,
+        trigger_id: UUID | str,
+        enabled: bool,
+    ) -> bool:
+        """Toggle trigger enabled state (internal transaction-aware helper)."""
+        if isinstance(trigger_id, str):
+            trigger_id = UUID(trigger_id)
+
+        table = sql.Identifier(f"{chancy.prefix}triggers")
+
+        # Get current trigger info
+        await cursor.execute(
+            sql.SQL("""
+                SELECT
+                    schema_name,
+                    table_name,
+                    trigger_name,
+                    operations,
+                    enabled
+                FROM {table} WHERE id = %(id)s
+            """).format(table=table),
+            {"id": trigger_id},
+        )
+
+        row = await cursor.fetchone()
+        if not row:
+            raise ValueError(f"Trigger {trigger_id} not found")
+
+        # Already in desired state - no change needed
+        if row["enabled"] == enabled:
+            return False
+
+        if enabled:
+            await cls._create_database_triggers(
+                cursor,
+                row["schema_name"],
+                row["table_name"],
+                row["trigger_name"],
+                row["operations"],
+                chancy.prefix,
+            )
+        else:
+            for operation in row["operations"]:
+                trigger_name = f"{row['trigger_name']}_{operation.lower()}"
+                await cls._drop_database_trigger(
+                    cursor,
+                    row["schema_name"],
+                    row["table_name"],
+                    trigger_name,
+                )
+
+        await cursor.execute(
+            sql.SQL("""
+                UPDATE
+                    {table}
+                SET
+                    enabled = %(enabled)s
+                WHERE id = %(id)s
+            """).format(table=table),
+            {"enabled": enabled, "id": trigger_id},
+        )
+
+        return True
+
+    @classmethod
+    async def get_triggers(
+        cls,
+        chancy: Chancy,
+        *,
+        trigger_ids: List[UUID | str] | None = None,
+    ) -> dict[UUID, TriggerConfig]:
+        """
+        Get registered triggers by their IDs.
+
+        Retrieves trigger configurations from the database. Can fetch all triggers
+        or filter by specific IDs.
+
+        Example:
+            >>> # Get all triggers
+            >>> all_triggers = await Trigger.get_triggers(chancy)
+            >>>
+            >>> # Get specific triggers
+            >>> triggers = await Trigger.get_triggers(
+            >>>     chancy,
+            >>>     trigger_ids=[trigger_id1, trigger_id2]
+            >>> )
+            >>> for trigger_id, config in triggers.items():
+            >>>     print(f"{config.table_name}: {config.enabled}")
+
+        :param chancy: The Chancy application instance.
+        :param trigger_ids: Optional list of trigger IDs to filter by (UUID or string).
+        :return: Dictionary mapping trigger UUID to TriggerConfig.
+        """
+        async with chancy.pool.connection() as conn:
+            async with conn.cursor(row_factory=dict_row) as cursor:
+                return await cls.get_triggers_ex(
+                    cursor, chancy, trigger_ids=trigger_ids
+                )
+
+    @classmethod
+    async def get_triggers_ex(
+        cls,
+        cursor: AsyncCursor[DictRow],
+        chancy: Chancy,
+        *,
+        trigger_ids: List[UUID | str] | None = None,
+    ) -> dict[UUID, TriggerConfig]:
+        """
+        Get registered triggers by their IDs (transaction-aware version).
+
+        :param cursor: The database cursor to use for the query.
+        :param chancy: The Chancy application instance.
+        :param trigger_ids: Optional list of trigger IDs to filter by (UUID or string).
+        :return: Dictionary mapping trigger UUID to TriggerConfig.
+        """
+        # Convert string IDs to UUIDs
+        if trigger_ids:
+            trigger_ids = [
+                UUID(tid) if isinstance(tid, str) else tid
+                for tid in trigger_ids
+            ]
+
+        table = sql.Identifier(f"{chancy.prefix}triggers")
+
+        await cursor.execute(
+            sql.SQL("""
+                SELECT
+                    id,
+                    table_name,
+                    schema_name,
+                    trigger_name,
+                    operations,
+                    job_template,
+                    enabled,
+                    created_at
+                FROM {table}
+                WHERE (%(trigger_ids)s::uuid[] IS NULL OR id = ANY(%(trigger_ids)s))
+                ORDER BY created_at DESC
+            """).format(table=table),
+            {"trigger_ids": trigger_ids},
+        )
+
+        return {
+            row["id"]: TriggerConfig(
+                id=row["id"],
+                table_name=row["table_name"],
+                schema_name=row["schema_name"],
+                trigger_name=row["trigger_name"],
+                operations=row["operations"],
+                job_template=Job.unpack(row["job_template"]),
+                enabled=row["enabled"],
+                created_at=row["created_at"],
+            )
+            async for row in cursor
+        }
+
+    @staticmethod
+    async def _ensure_trigger_function(cursor, prefix: str):
+        """Ensure the trigger function exists in the database."""
+        await cursor.execute(
+            sql.SQL("""
+                CREATE OR REPLACE FUNCTION {function_name}()
+                RETURNS TRIGGER AS $func$
+                DECLARE
+                    trigger_config RECORD;
+                    job_data JSONB;
+                BEGIN
+                    -- Fetch trigger configuration
+                    SELECT job_template INTO trigger_config
+                    FROM {triggers_table}
+                    WHERE schema_name = TG_TABLE_SCHEMA 
+                      AND table_name = TG_TABLE_NAME 
+                      AND trigger_name = REPLACE(TG_NAME, '_' || lower(TG_OP), '')
+                      AND enabled = true
+                      AND operations::jsonb ? TG_OP;
+                    
+                    IF NOT FOUND THEN
+                        RETURN NULL;
+                    END IF;
+                    
+                    job_data := trigger_config.job_template::jsonb;
+                    job_data := jsonb_set(
+                        job_data,
+                        '{{m,trigger}}',
+                        jsonb_build_object(
+                            'operation', TG_OP,
+                            'table_name', TG_TABLE_NAME,
+                            'schema_name', TG_TABLE_SCHEMA,
+                            'trigger_name', TG_NAME,
+                            'timestamp', NOW()
+                        )
+                    );
+                    
+                    -- Insert job into queue
+                    INSERT INTO {jobs_table} (
+                        id,
+                        queue,
+                        func,
+                        kwargs,
+                        priority,
+                        max_attempts, 
+                        scheduled_at,
+                        limits,
+                        unique_key,
+                        meta,
+                        state,
+                        created_at
+                    ) VALUES (
+                        gen_random_uuid(),
+                        job_data->>'q',
+                        job_data->>'f', 
+                        COALESCE(job_data->'k', '{{}}'::jsonb),
+                        COALESCE((job_data->>'p')::integer, 0),
+                        COALESCE((job_data->>'a')::integer, 1),
+                        COALESCE(
+                            to_timestamp((job_data->>'s')::double precision),
+                            NOW()
+                        ),
+                        COALESCE(job_data->'l', '[]'::jsonb),
+                        job_data->>'u',
+                        COALESCE(job_data->'m', '{{}}'::jsonb),
+                        'pending',
+                        NOW()
+                    )
+                    ON CONFLICT (unique_key)
+                    WHERE
+                        unique_key IS NOT NULL
+                            AND state NOT IN ('succeeded', 'failed')
+                    DO NOTHING;
+                    PERFORM pg_notify(
+                       {notify_channel},
+                       json_build_object(
+                           't', 'queue.pushed',
+                           'q', job_data->>'q'
+                       )::text
+                    );
+                    RETURN NULL;
+                END;
+                $func$ LANGUAGE plpgsql;
+            """).format(
+                function_name=sql.Identifier(f"{prefix}trigger_handler"),
+                triggers_table=sql.Identifier(f"{prefix}triggers"),
+                jobs_table=sql.Identifier(f"{prefix}jobs"),
+                notify_channel=sql.Literal(f"{prefix}events"),
+            )
+        )
+
+    @staticmethod
+    async def _create_database_triggers(
+        cursor,
+        schema_name: str,
+        table_name: str,
+        trigger_name: str,
+        operations: list[str],
+        prefix: str,
+    ):
+        """Create PostgreSQL triggers for the specified operations."""
+        for operation in operations:
+            op_trigger_name = f"{trigger_name}_{operation.lower()}"
+
+            await cursor.execute(
+                sql.SQL("""
+                    CREATE TRIGGER {trigger_name}
+                    AFTER {operation} ON {schema}.{table}
+                    FOR EACH STATEMENT EXECUTE FUNCTION {function_name}()
+                """).format(
+                    trigger_name=sql.Identifier(op_trigger_name),
+                    operation=sql.SQL(operation.upper()),
+                    schema=sql.Identifier(schema_name),
+                    table=sql.Identifier(table_name),
+                    function_name=sql.Identifier(f"{prefix}trigger_handler"),
+                )
+            )
+
+    @staticmethod
+    async def _drop_database_trigger(
+        cursor, schema_name: str, table_name: str, trigger_name: str
+    ):
+        """Drop a PostgreSQL trigger if it exists."""
+        await cursor.execute(
+            sql.SQL("""
+                DROP TRIGGER IF EXISTS {trigger_name} ON {schema}.{table}
+            """).format(
+                trigger_name=sql.Identifier(trigger_name),
+                schema=sql.Identifier(schema_name),
+                table=sql.Identifier(table_name),
+            )
+        )

--- a/chancy/plugins/trigger/migrations/__init__.py
+++ b/chancy/plugins/trigger/migrations/__init__.py
@@ -1,0 +1,1 @@
+# Trigger plugin migrations package

--- a/chancy/plugins/trigger/migrations/v1.py
+++ b/chancy/plugins/trigger/migrations/v1.py
@@ -1,0 +1,85 @@
+from psycopg import AsyncCursor, sql
+from psycopg.rows import DictRow
+
+from chancy.migrate import Migration, Migrator
+
+
+class V1Migration(Migration):
+    async def up(self, migrator: Migrator, cursor: AsyncCursor[DictRow]):
+        """
+        Create the triggers configuration table.
+        """
+        await cursor.execute(
+            sql.SQL("""
+                CREATE TABLE {table} (
+                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                    table_name TEXT NOT NULL,
+                    schema_name TEXT NOT NULL DEFAULT 'public',
+                    trigger_name TEXT NOT NULL,
+                    operations JSONB NOT NULL,
+                    job_template JSONB NOT NULL,
+                    enabled BOOLEAN NOT NULL DEFAULT true,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    UNIQUE(schema_name, table_name, trigger_name)
+                )
+            """).format(table=sql.Identifier(f"{migrator.prefix}triggers"))
+        )
+
+        await cursor.execute(
+            sql.SQL("""
+                CREATE INDEX {index_name}
+                ON {table} (schema_name, table_name, trigger_name)
+                WHERE enabled = true
+            """).format(
+                index_name=sql.Identifier(
+                    f"{migrator.prefix}triggers_lookup_idx"
+                ),
+                table=sql.Identifier(f"{migrator.prefix}triggers"),
+            )
+        )
+
+    async def down(self, migrator: Migrator, cursor: AsyncCursor[DictRow]):
+        """
+        Drop the triggers table and clean up any remaining trigger functions.
+        """
+        await cursor.execute(
+            sql.SQL("""
+                DO $$
+                DECLARE
+                    trigger_rec RECORD;
+                BEGIN
+                    FOR trigger_rec IN 
+                        SELECT 
+                            tg.tgname AS triggername,
+                            n.nspname AS schemaname,
+                            c.relname AS tablename
+                        FROM pg_catalog.pg_trigger tg
+                        JOIN pg_catalog.pg_class c ON tg.tgrelid = c.oid
+                        JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+                        WHERE NOT tg.tgisinternal
+                          AND tg.tgname LIKE {prefix}
+                    LOOP
+                        EXECUTE format(
+                            'DROP TRIGGER IF EXISTS %I ON %I.%I',
+                            trigger_rec.triggername, 
+                            trigger_rec.schemaname, 
+                            trigger_rec.tablename
+                        );
+                    END LOOP;
+                END $$;
+            """).format(prefix=sql.Literal(f"{migrator.prefix}trigger_%")),
+        )
+
+        await cursor.execute(
+            sql.SQL("DROP FUNCTION IF EXISTS {function_name}()").format(
+                function_name=sql.Identifier(
+                    f"{migrator.prefix}trigger_handler"
+                )
+            )
+        )
+
+        await cursor.execute(
+            sql.SQL("DROP TABLE IF EXISTS {table}").format(
+                table=sql.Identifier(f"{migrator.prefix}triggers")
+            )
+        )

--- a/chancy/plugins/workflow/__init__.py
+++ b/chancy/plugins/workflow/__init__.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from functools import partial
 from typing import List, Dict, TextIO, Self
 from psycopg import sql, AsyncCursor
-from psycopg.rows import dict_row
+from psycopg.rows import dict_row, DictRow
 
 from chancy.hub import Event
 from chancy.plugin import Plugin
@@ -14,6 +14,51 @@ from chancy.worker import Worker
 from chancy.job import Job, QueuedJob, IsAJob
 from chancy.utils import json_dumps, chancy_uuid
 from chancy.rule import Rule
+
+
+class CircularDependencyError(ValueError):
+    """Raised when a circular dependency is detected in a workflow."""
+
+    pass
+
+
+class InvalidDependencyError(ValueError):
+    """Raised when a dependency references a non-existent step."""
+
+    pass
+
+
+def _dfs_detect_cycle(
+    step_id: str,
+    steps: Dict[str, "WorkflowStep"],
+    color: Dict[str, int],
+    path: List[str],
+) -> None:
+    """
+    DFS helper to detect cycles in workflow dependency graph.
+
+    :param step_id: Current step being visited.
+    :param steps: Dictionary of all workflow steps.
+    :param color: Color mapping (0=WHITE/unvisited, 1=GRAY/in-stack, 2=BLACK/processed).
+    :param path: Current path in the recursion stack.
+    :raises CircularDependencyError: If a cycle is detected.
+    """
+    color[step_id] = 1  # Mark as GRAY (in recursion stack)
+    path.append(step_id)
+
+    for dep_id in steps[step_id].dependencies:
+        if color[dep_id] == 1:  # GRAY - cycle detected
+            # Find where the cycle starts
+            cycle_start = path.index(dep_id)
+            cycle_path = " -> ".join(path[cycle_start:] + [dep_id])
+            raise CircularDependencyError(
+                f"Circular dependency detected: {cycle_path}"
+            )
+        elif color[dep_id] == 0:  # WHITE - unvisited
+            _dfs_detect_cycle(dep_id, steps, color, path)
+
+    path.pop()
+    color[step_id] = 2  # Mark as BLACK (processed)
 
 
 @dataclass
@@ -128,6 +173,35 @@ class Workflow:
     @property
     def is_running(self) -> bool:
         return self.state == self.State.RUNNING
+
+    def validate(self) -> None:
+        """
+        Validate the workflow's dependency graph.
+
+        This method checks for:
+        - Circular dependencies (cycles in the dependency graph)
+        - Invalid dependencies (references to non-existent steps)
+
+        :raises CircularDependencyError: If a circular dependency is detected.
+        :raises InvalidDependencyError: If a dependency references a non-existent step.
+        """
+        # First, check that all dependencies reference existing steps
+        for step_id, step in self.steps.items():
+            for dep_id in step.dependencies:
+                if dep_id not in self.steps:
+                    raise InvalidDependencyError(
+                        f"Step '{step_id}' depends on non-existent step '{dep_id}'"
+                    )
+
+        # Detect cycles using DFS with three-color marking
+        # WHITE (0) = unvisited, GRAY (1) = in recursion stack, BLACK (2) = processed
+        color = {step_id: 0 for step_id in self.steps}
+        path: List[str] = []
+
+        # Run DFS from all unvisited nodes
+        for step_id in self.steps:
+            if color[step_id] == 0:
+                _dfs_detect_cycle(step_id, self.steps, color, path)
 
     @property
     def steps_by_state(self) -> Dict[QueuedJob.State, List[WorkflowStep]]:
@@ -404,7 +478,7 @@ class WorkflowPlugin(Plugin):
 
     @classmethod
     async def fetch_workflow_ex(
-        cls, cursor: AsyncCursor, chancy: Chancy, id_: str
+        cls, cursor: AsyncCursor[DictRow], chancy: Chancy, id_: str
     ) -> Workflow | None:
         """
         Fetch a single workflow from the database.
@@ -451,7 +525,7 @@ class WorkflowPlugin(Plugin):
 
     @staticmethod
     async def fetch_workflows_ex(
-        cursor: AsyncCursor,
+        cursor: AsyncCursor[DictRow],
         chancy: Chancy,
         *,
         states: list[str] | None = None,
@@ -624,7 +698,7 @@ class WorkflowPlugin(Plugin):
 
     @staticmethod
     async def push_ex(
-        cursor: AsyncCursor, chancy: Chancy, workflow: Workflow
+        cursor: AsyncCursor[DictRow], chancy: Chancy, workflow: Workflow
     ) -> str:
         """
         Push new workflow to the database.
@@ -639,7 +713,11 @@ class WorkflowPlugin(Plugin):
         :param chancy: The Chancy application.
         :param workflow: The workflow to push.
         :return: The UUID of the newly created workflow.
+        :raises CircularDependencyError: If a circular dependency is detected.
+        :raises InvalidDependencyError: If a dependency references a non-existent step.
         """
+        workflow.validate()
+
         await cursor.execute(
             sql.SQL(
                 """

--- a/chancy/plugins/workflow/__init__.py
+++ b/chancy/plugins/workflow/__init__.py
@@ -488,7 +488,7 @@ class WorkflowPlugin(Plugin):
                             'dependencies', ws.dependencies,
                             'state', j.state,
                             'job_id', ws.job_id
-                        )
+                        ) order by ws.step_id
                     ), '[]'::json) as steps
                 FROM {workflows} w
                 LEFT JOIN {workflow_steps} ws ON w.id = ws.workflow_id

--- a/chancy/plugins/workflow/__init__.py
+++ b/chancy/plugins/workflow/__init__.py
@@ -345,7 +345,7 @@ class WorkflowPlugin(Plugin):
         progressed to the next step without waiting for the next polling
         interval.
         """
-        if not worker.is_leader:
+        if not worker.is_leader.is_set():
             return
 
         async with chancy.pool.connection() as conn:

--- a/docs/chancy.plugins.rst
+++ b/docs/chancy.plugins.rst
@@ -12,13 +12,14 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   chancy.plugins.api
+   chancy.plugins.cron
    chancy.plugins.leadership
+   chancy.plugins.metrics
    chancy.plugins.pruner
    chancy.plugins.recovery
-   chancy.plugins.cron
-   chancy.plugins.api
-   chancy.plugins.workflow
-   chancy.plugins.retry
    chancy.plugins.reprioritize
+   chancy.plugins.retry
    chancy.plugins.sentry
-   chancy.plugins.metrics
+   chancy.plugins.trigger
+   chancy.plugins.workflow

--- a/docs/chancy.plugins.trigger.rst
+++ b/docs/chancy.plugins.trigger.rst
@@ -1,0 +1,12 @@
+Triggers
+========
+
+.. autoclass:: chancy.plugins.trigger.Trigger
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: chancy.plugins.trigger.TriggerConfig
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "pytest-benchmark>=5.1.0",
     "pytest-django>=4.8.0",
     "pre-commit>=4.3.0",
+    "ruff>=0.14.2",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,8 @@ django = [
     "django>=4.0.0",
 ]
 
-[project.scripts]
-chancy = "chancy.cli.cli:main"
-
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest-asyncio>=0.24.0",
     "pytest>=8.2.0",
     "sphinx>=7.3.7",
@@ -59,6 +56,9 @@ dev-dependencies = [
     "pytest-benchmark>=5.1.0",
     "pytest-django>=4.8.0",
 ]
+
+[project.scripts]
+chancy = "chancy.cli.cli:main"
 
 [tool.hatch.build.targets.wheel]
 artifacts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "ghp-import>=2.1.0",
     "pytest-benchmark>=5.1.0",
     "pytest-django>=4.8.0",
+    "pre-commit>=4.3.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chancy"
-version = "0.25.0"
+version = "0.25.1"
 description = "A simple and flexible job queue for Python"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [project.urls]

--- a/tests/plugins/test_trigger.py
+++ b/tests/plugins/test_trigger.py
@@ -1,0 +1,790 @@
+import uuid
+import pytest
+
+import pytest_asyncio
+from psycopg import sql
+
+from chancy import job, Queue, Reference, Chancy, QueuedJob
+from chancy.plugins.trigger import Trigger
+
+
+@job(queue="trigger_events")
+def handle_insert(*, j: QueuedJob):
+    """Test job for INSERT operations"""
+    assert j.meta["trigger"]["operation"] == "INSERT"
+    assert j.meta["trigger"]["table_name"] == "test_users"
+    assert j.meta["trigger"]["schema_name"] == "public"
+
+
+@job(queue="trigger_events")
+def handle_update(*, j: QueuedJob):
+    """Test job for UPDATE operations"""
+    assert j.meta["trigger"]["operation"] == "UPDATE"
+
+
+@job(queue="trigger_events")
+def handle_delete(*, j: QueuedJob):
+    """Test job for DELETE operations"""
+    assert j.meta["trigger"]["operation"] == "DELETE"
+
+
+@job(queue="trigger_events")
+def handle_any_change(*, j: QueuedJob):
+    """Test job for any operation"""
+    assert j.meta["trigger"]["operation"] in ["INSERT", "UPDATE", "DELETE"]
+
+
+@job(queue="trigger_events", priority=10)
+def handle_with_priority(*, j: QueuedJob):
+    """Test job with priority"""
+    assert j.meta["trigger"]["table_name"] == "test_users"
+
+
+# Keep old name for backward compatibility with existing test
+handle_table_change = handle_insert
+
+
+@pytest_asyncio.fixture
+async def test_table(chancy):
+    table_name = "test_users"
+
+    async with chancy.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute(
+                sql.SQL("""
+                    CREATE TABLE IF NOT EXISTS {table} (
+                        id SERIAL PRIMARY KEY,
+                        name TEXT NOT NULL,
+                        email TEXT UNIQUE NOT NULL
+                    )
+                """).format(table=sql.Identifier(table_name))
+            )
+
+    yield table_name
+
+    async with chancy.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute(
+                sql.SQL("DROP TABLE IF EXISTS {table}").format(
+                    table=sql.Identifier(table_name)
+                )
+            )
+
+
+@pytest.mark.parametrize(
+    "chancy",
+    [{"plugins": [Trigger()], "no_default_plugins": True}],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_trigger_creates_job_on_change(
+    chancy: Chancy, worker, test_table
+):
+    """Test that database changes create jobs"""
+    await chancy.declare(Queue("trigger_events"))
+
+    # Register a trigger that listens for INSERT operations on the test table
+    # and runs the handle_table_change job when such an operation occurs.
+    trigger_id = await Trigger.register_trigger(
+        chancy,
+        table_name=test_table,
+        operations=["INSERT"],
+        job_template=handle_table_change,
+    )
+
+    async with chancy.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            async with conn.transaction():
+                await cursor.execute(
+                    sql.SQL("""
+                        INSERT INTO {table} (name, email)
+                        VALUES ('John Doe', 'john@example.com')
+                    """).format(table=sql.Identifier(test_table))
+                )
+
+            await cursor.execute(
+                sql.SQL("""
+                    SELECT id
+                    FROM {jobs_table}
+                    WHERE func = %s
+                    AND state = 'pending'
+                """).format(jobs_table=sql.Identifier(f"{chancy.prefix}jobs")),
+                (handle_table_change.job.func,),
+            )
+
+            jobs = await cursor.fetchall()
+            assert len(jobs) == 1, "Trigger should create exactly one job"
+
+            ref = Reference(jobs[0][0])
+            j = await chancy.wait_for_job(ref)
+            assert j, "Job did not complete successfully"
+
+    # Now let us disable the trigger and ensure no new jobs are created
+    await Trigger.disable_trigger(chancy, trigger_id)
+    async with chancy.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            async with conn.transaction():
+                await cursor.execute(
+                    sql.SQL("""
+                        INSERT INTO {table} (name, email)
+                        VALUES ('Jane Doe', 'jane@example.com')
+                    """).format(table=sql.Identifier(test_table))
+                )
+
+            await cursor.execute(
+                sql.SQL("""
+                    SELECT id
+                    FROM {jobs_table}
+                    WHERE func = %s
+                    AND state = 'pending'
+                """).format(jobs_table=sql.Identifier(f"{chancy.prefix}jobs")),
+                (handle_table_change.job.func,),
+            )
+
+            jobs = await cursor.fetchall()
+            assert (
+                len(jobs) == 0
+            ), "Trigger should not create jobs when disabled"
+
+
+@pytest.mark.parametrize(
+    "chancy",
+    [{"plugins": [Trigger()], "no_default_plugins": True}],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_trigger_update_operation(chancy: Chancy, worker, test_table):
+    """Test that UPDATE operations create jobs"""
+    await chancy.declare(Queue("trigger_events"))
+
+    await Trigger.register_trigger(
+        chancy,
+        table_name=test_table,
+        operations=["UPDATE"],
+        job_template=handle_update,
+    )
+
+    async with chancy.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            # First insert a row
+            async with conn.transaction():
+                await cursor.execute(
+                    sql.SQL("""
+                        INSERT INTO {table} (name, email)
+                        VALUES ('John Doe', 'john@example.com')
+                    """).format(table=sql.Identifier(test_table))
+                )
+
+            # Now update it
+            async with conn.transaction():
+                await cursor.execute(
+                    sql.SQL("""
+                        UPDATE {table}
+                        SET name = 'Jane Doe'
+                        WHERE email = 'john@example.com'
+                    """).format(table=sql.Identifier(test_table))
+                )
+
+            await cursor.execute(
+                sql.SQL("""
+                    SELECT id
+                    FROM {jobs_table}
+                    WHERE func = %s
+                    AND state = 'pending'
+                """).format(jobs_table=sql.Identifier(f"{chancy.prefix}jobs")),
+                (handle_update.job.func,),
+            )
+
+            jobs = await cursor.fetchall()
+            assert (
+                len(jobs) == 1
+            ), "UPDATE trigger should create exactly one job"
+
+            ref = Reference(jobs[0][0])
+            j = await chancy.wait_for_job(ref)
+            assert j, "Job did not complete successfully"
+
+
+@pytest.mark.parametrize(
+    "chancy",
+    [{"plugins": [Trigger()], "no_default_plugins": True}],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_trigger_delete_operation(chancy: Chancy, worker, test_table):
+    """Test that DELETE operations create jobs"""
+    await chancy.declare(Queue("trigger_events"))
+
+    await Trigger.register_trigger(
+        chancy,
+        table_name=test_table,
+        operations=["DELETE"],
+        job_template=handle_delete,
+    )
+
+    async with chancy.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            # First insert a row
+            async with conn.transaction():
+                await cursor.execute(
+                    sql.SQL("""
+                        INSERT INTO {table} (name, email)
+                        VALUES ('John Doe', 'john@example.com')
+                    """).format(table=sql.Identifier(test_table))
+                )
+
+            # Now delete it
+            async with conn.transaction():
+                await cursor.execute(
+                    sql.SQL("""
+                        DELETE FROM {table}
+                        WHERE email = 'john@example.com'
+                    """).format(table=sql.Identifier(test_table))
+                )
+
+            await cursor.execute(
+                sql.SQL("""
+                    SELECT id
+                    FROM {jobs_table}
+                    WHERE func = %s
+                    AND state = 'pending'
+                """).format(jobs_table=sql.Identifier(f"{chancy.prefix}jobs")),
+                (handle_delete.job.func,),
+            )
+
+            jobs = await cursor.fetchall()
+            assert (
+                len(jobs) == 1
+            ), "DELETE trigger should create exactly one job"
+
+            ref = Reference(jobs[0][0])
+            j = await chancy.wait_for_job(ref)
+            assert j, "Job did not complete successfully"
+
+
+@pytest.mark.parametrize(
+    "chancy",
+    [{"plugins": [Trigger()], "no_default_plugins": True}],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_trigger_multiple_operations(chancy: Chancy, worker, test_table):
+    """Test trigger with multiple operations (INSERT, UPDATE, DELETE)"""
+    await chancy.declare(Queue("trigger_events"))
+
+    await Trigger.register_trigger(
+        chancy,
+        table_name=test_table,
+        operations=["INSERT", "UPDATE", "DELETE"],
+        job_template=handle_any_change,
+    )
+
+    async with chancy.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            # INSERT
+            async with conn.transaction():
+                await cursor.execute(
+                    sql.SQL("""
+                        INSERT INTO {table} (name, email)
+                        VALUES ('John Doe', 'john@example.com')
+                    """).format(table=sql.Identifier(test_table))
+                )
+
+            # UPDATE
+            async with conn.transaction():
+                await cursor.execute(
+                    sql.SQL("""
+                        UPDATE {table}
+                        SET name = 'Jane Doe'
+                        WHERE email = 'john@example.com'
+                    """).format(table=sql.Identifier(test_table))
+                )
+
+            # DELETE
+            async with conn.transaction():
+                await cursor.execute(
+                    sql.SQL("""
+                        DELETE FROM {table}
+                        WHERE email = 'john@example.com'
+                    """).format(table=sql.Identifier(test_table))
+                )
+
+            # Query for all jobs created by this trigger (any state)
+            await cursor.execute(
+                sql.SQL("""
+                    SELECT id
+                    FROM {jobs_table}
+                    WHERE func = %s
+                    ORDER BY created_at ASC
+                """).format(jobs_table=sql.Identifier(f"{chancy.prefix}jobs")),
+                (handle_any_change.job.func,),
+            )
+
+            jobs = await cursor.fetchall()
+            assert (
+                len(jobs) == 3
+            ), f"Should create 3 jobs (INSERT, UPDATE, DELETE), got {len(jobs)}"
+
+            # Wait for all jobs to complete
+            for job_row in jobs:
+                ref = Reference(job_row[0])
+                j = await chancy.wait_for_job(ref)
+                assert j, "Job did not complete successfully"
+
+
+@pytest.mark.parametrize(
+    "chancy",
+    [{"plugins": [Trigger()], "no_default_plugins": True}],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_unregister_trigger(chancy: Chancy, worker, test_table):
+    """Test that unregistering a trigger removes it completely"""
+    await chancy.declare(Queue("trigger_events"))
+
+    trigger_id = await Trigger.register_trigger(
+        chancy,
+        table_name=test_table,
+        operations=["INSERT"],
+        job_template=handle_insert,
+    )
+
+    # Verify trigger exists
+    triggers = await Trigger.get_triggers(chancy, trigger_ids=[trigger_id])
+    assert len(triggers) == 1
+    assert trigger_id in triggers
+    assert triggers[trigger_id].enabled is True
+
+    # Unregister it
+    await Trigger.unregister_trigger(chancy, trigger_id)
+
+    # Verify it's gone
+    triggers = await Trigger.get_triggers(chancy, trigger_ids=[trigger_id])
+    assert len(triggers) == 0
+
+    # Verify no jobs are created
+    async with chancy.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            async with conn.transaction():
+                await cursor.execute(
+                    sql.SQL("""
+                        INSERT INTO {table} (name, email)
+                        VALUES ('John Doe', 'john@example.com')
+                    """).format(table=sql.Identifier(test_table))
+                )
+
+            await cursor.execute(
+                sql.SQL("""
+                    SELECT id
+                    FROM {jobs_table}
+                    WHERE func = %s
+                    AND state = 'pending'
+                """).format(jobs_table=sql.Identifier(f"{chancy.prefix}jobs")),
+                (handle_insert.job.func,),
+            )
+
+            jobs = await cursor.fetchall()
+            assert len(jobs) == 0, "Unregistered trigger should not create jobs"
+
+
+@pytest.mark.parametrize(
+    "chancy",
+    [{"plugins": [Trigger()], "no_default_plugins": True}],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_enable_trigger(chancy: Chancy, worker, test_table):
+    """Test re-enabling a disabled trigger"""
+    await chancy.declare(Queue("trigger_events"))
+
+    trigger_id = await Trigger.register_trigger(
+        chancy,
+        table_name=test_table,
+        operations=["INSERT"],
+        job_template=handle_insert,
+    )
+
+    # Disable it
+    changed = await Trigger.disable_trigger(chancy, trigger_id)
+    assert changed is True
+
+    # Verify no jobs created when disabled
+    async with chancy.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            async with conn.transaction():
+                await cursor.execute(
+                    sql.SQL("""
+                        INSERT INTO {table} (name, email)
+                        VALUES ('Disabled User', 'disabled@example.com')
+                    """).format(table=sql.Identifier(test_table))
+                )
+
+            await cursor.execute(
+                sql.SQL("""
+                    SELECT id
+                    FROM {jobs_table}
+                    WHERE func = %s
+                    AND state = 'pending'
+                """).format(jobs_table=sql.Identifier(f"{chancy.prefix}jobs")),
+                (handle_insert.job.func,),
+            )
+
+            jobs = await cursor.fetchall()
+            assert len(jobs) == 0
+
+    # Re-enable it
+    changed = await Trigger.enable_trigger(chancy, trigger_id)
+    assert changed is True
+
+    # Verify jobs are created again
+    async with chancy.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            async with conn.transaction():
+                await cursor.execute(
+                    sql.SQL("""
+                        INSERT INTO {table} (name, email)
+                        VALUES ('Enabled User', 'enabled@example.com')
+                    """).format(table=sql.Identifier(test_table))
+                )
+
+            await cursor.execute(
+                sql.SQL("""
+                    SELECT id
+                    FROM {jobs_table}
+                    WHERE func = %s
+                    AND state = 'pending'
+                """).format(jobs_table=sql.Identifier(f"{chancy.prefix}jobs")),
+                (handle_insert.job.func,),
+            )
+
+            jobs = await cursor.fetchall()
+            assert len(jobs) == 1, "Re-enabled trigger should create jobs"
+
+
+@pytest.mark.parametrize(
+    "chancy",
+    [{"plugins": [Trigger()], "no_default_plugins": True}],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_get_triggers(chancy: Chancy, worker, test_table):
+    """Test retrieving trigger information"""
+    await chancy.declare(Queue("trigger_events"))
+
+    # Create multiple triggers
+    trigger_id1 = await Trigger.register_trigger(
+        chancy,
+        table_name=test_table,
+        operations=["INSERT"],
+        job_template=handle_insert,
+    )
+
+    trigger_id2 = await Trigger.register_trigger(
+        chancy,
+        table_name=test_table,
+        operations=["UPDATE"],
+        job_template=handle_update,
+    )
+
+    # Get all triggers
+    all_triggers = await Trigger.get_triggers(chancy)
+    assert len(all_triggers) >= 2
+
+    # Get specific triggers
+    specific_triggers = await Trigger.get_triggers(
+        chancy, trigger_ids=[trigger_id1, trigger_id2]
+    )
+    assert len(specific_triggers) == 2
+    assert trigger_id1 in specific_triggers
+    assert trigger_id2 in specific_triggers
+
+    # Verify trigger data
+    trigger1 = specific_triggers[trigger_id1]
+    assert trigger1.table_name == test_table
+    assert trigger1.schema_name == "public"
+    assert trigger1.operations == ["INSERT"]
+    assert trigger1.enabled is True
+    assert trigger1.job_template.func == handle_insert.job.func
+
+
+@pytest.mark.parametrize(
+    "chancy",
+    [{"plugins": [Trigger()], "no_default_plugins": True}],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_trigger_invalid_operation(chancy: Chancy, worker, test_table):
+    """Test that invalid operations raise ValueError"""
+    await chancy.declare(Queue("trigger_events"))
+
+    with pytest.raises(ValueError, match="Invalid operation"):
+        await Trigger.register_trigger(
+            chancy,
+            table_name=test_table,
+            operations=["INVALID_OP"],
+            job_template=handle_insert,
+        )
+
+
+@pytest.mark.parametrize(
+    "chancy",
+    [{"plugins": [Trigger()], "no_default_plugins": True}],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_unregister_nonexistent_trigger(
+    chancy: Chancy, worker, test_table
+):
+    """Test that unregistering a non-existent trigger raises ValueError"""
+    nonexistent_id = str(uuid.uuid4())
+    with pytest.raises(ValueError, match="Trigger .* not found"):
+        await Trigger.unregister_trigger(chancy, nonexistent_id)
+
+
+@pytest.mark.parametrize(
+    "chancy",
+    [{"plugins": [Trigger()], "no_default_plugins": True}],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_enable_nonexistent_trigger(chancy: Chancy, worker, test_table):
+    """Test that enabling a non-existent trigger raises ValueError"""
+    nonexistent_id = str(uuid.uuid4())
+    with pytest.raises(ValueError, match="Trigger .* not found"):
+        await Trigger.enable_trigger(chancy, nonexistent_id)
+
+
+@pytest.mark.parametrize(
+    "chancy",
+    [{"plugins": [Trigger()], "no_default_plugins": True}],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_disable_nonexistent_trigger(chancy: Chancy, worker, test_table):
+    """Test that disabling a non-existent trigger raises ValueError"""
+    nonexistent_id = str(uuid.uuid4())
+    with pytest.raises(ValueError, match="Trigger .* not found"):
+        await Trigger.disable_trigger(chancy, nonexistent_id)
+
+
+@pytest.mark.parametrize(
+    "chancy",
+    [{"plugins": [Trigger()], "no_default_plugins": True}],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_trigger_bulk_operations(chancy: Chancy, worker, test_table):
+    """Test that statement-level triggers fire once per statement, not per row"""
+    await chancy.declare(Queue("trigger_events"))
+
+    await Trigger.register_trigger(
+        chancy,
+        table_name=test_table,
+        operations=["INSERT"],
+        job_template=handle_insert,
+    )
+
+    async with chancy.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            # Bulk insert 5 rows in one statement
+            async with conn.transaction():
+                await cursor.execute(
+                    sql.SQL("""
+                        INSERT INTO {table} (name, email)
+                        VALUES
+                            ('User 1', 'user1@example.com'),
+                            ('User 2', 'user2@example.com'),
+                            ('User 3', 'user3@example.com'),
+                            ('User 4', 'user4@example.com'),
+                            ('User 5', 'user5@example.com')
+                    """).format(table=sql.Identifier(test_table))
+                )
+
+            await cursor.execute(
+                sql.SQL("""
+                    SELECT id
+                    FROM {jobs_table}
+                    WHERE func = %s
+                    AND state = 'pending'
+                """).format(jobs_table=sql.Identifier(f"{chancy.prefix}jobs")),
+                (handle_insert.job.func,),
+            )
+
+            jobs = await cursor.fetchall()
+            # Statement-level trigger should fire once per statement, not per row
+            assert (
+                len(jobs) == 1
+            ), "Statement-level trigger should create 1 job for bulk insert"
+
+
+@pytest.mark.parametrize(
+    "chancy",
+    [{"plugins": [Trigger()], "no_default_plugins": True}],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_trigger_with_job_parameters(chancy: Chancy, worker, test_table):
+    """Test trigger with job template that has priority and other parameters"""
+    await chancy.declare(Queue("trigger_events"))
+
+    await Trigger.register_trigger(
+        chancy,
+        table_name=test_table,
+        operations=["INSERT"],
+        job_template=handle_with_priority,
+    )
+
+    async with chancy.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            async with conn.transaction():
+                await cursor.execute(
+                    sql.SQL("""
+                        INSERT INTO {table} (name, email)
+                        VALUES ('Priority User', 'priority@example.com')
+                    """).format(table=sql.Identifier(test_table))
+                )
+
+            await cursor.execute(
+                sql.SQL("""
+                    SELECT id, priority
+                    FROM {jobs_table}
+                    WHERE func = %s
+                    AND state = 'pending'
+                """).format(jobs_table=sql.Identifier(f"{chancy.prefix}jobs")),
+                (handle_with_priority.job.func,),
+            )
+
+            jobs = await cursor.fetchall()
+            assert len(jobs) == 1
+            assert jobs[0][1] == 10, "Job should have priority 10"
+
+
+@pytest.mark.parametrize(
+    "chancy",
+    [{"plugins": [Trigger()], "no_default_plugins": True}],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_trigger_disabled_at_registration(
+    chancy: Chancy, worker, test_table
+):
+    """Test registering a trigger with enabled=False"""
+    await chancy.declare(Queue("trigger_events"))
+
+    trigger_id = await Trigger.register_trigger(
+        chancy,
+        table_name=test_table,
+        operations=["INSERT"],
+        job_template=handle_insert,
+        enabled=False,
+    )
+
+    # Verify trigger is disabled
+    triggers = await Trigger.get_triggers(chancy, trigger_ids=[trigger_id])
+    assert trigger_id in triggers
+    assert triggers[trigger_id].enabled is False
+
+    # Verify no jobs are created
+    async with chancy.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            async with conn.transaction():
+                await cursor.execute(
+                    sql.SQL("""
+                        INSERT INTO {table} (name, email)
+                        VALUES ('Test User', 'test@example.com')
+                    """).format(table=sql.Identifier(test_table))
+                )
+
+            await cursor.execute(
+                sql.SQL("""
+                    SELECT id
+                    FROM {jobs_table}
+                    WHERE func = %s
+                    AND state = 'pending'
+                """).format(jobs_table=sql.Identifier(f"{chancy.prefix}jobs")),
+                (handle_insert.job.func,),
+            )
+
+            jobs = await cursor.fetchall()
+            assert len(jobs) == 0, "Disabled trigger should not create jobs"
+
+
+@pytest_asyncio.fixture
+async def test_schema(chancy):
+    """Create a test schema for schema-specific tests"""
+    schema_name = "test_schema"
+
+    async with chancy.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute(
+                sql.SQL("CREATE SCHEMA IF NOT EXISTS {schema}").format(
+                    schema=sql.Identifier(schema_name)
+                )
+            )
+            await cursor.execute(
+                sql.SQL("""
+                    CREATE TABLE IF NOT EXISTS {schema}.{table} (
+                        id SERIAL PRIMARY KEY,
+                        name TEXT NOT NULL,
+                        email TEXT UNIQUE NOT NULL
+                    )
+                """).format(
+                    schema=sql.Identifier(schema_name),
+                    table=sql.Identifier("test_users"),
+                )
+            )
+
+    yield schema_name
+
+    async with chancy.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute(
+                sql.SQL("DROP SCHEMA IF EXISTS {schema} CASCADE").format(
+                    schema=sql.Identifier(schema_name)
+                )
+            )
+
+
+@pytest.mark.parametrize(
+    "chancy",
+    [{"plugins": [Trigger()], "no_default_plugins": True}],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_trigger_different_schema(chancy: Chancy, worker, test_schema):
+    """Test trigger on a table in a non-public schema"""
+    await chancy.declare(Queue("trigger_events"))
+
+    await Trigger.register_trigger(
+        chancy,
+        table_name="test_users",
+        operations=["INSERT"],
+        job_template=handle_insert,
+        schema_name=test_schema,
+    )
+
+    async with chancy.pool.connection() as conn:
+        async with conn.cursor() as cursor:
+            async with conn.transaction():
+                await cursor.execute(
+                    sql.SQL("""
+                        INSERT INTO {schema}.{table} (name, email)
+                        VALUES ('Schema User', 'schema@example.com')
+                    """).format(
+                        schema=sql.Identifier(test_schema),
+                        table=sql.Identifier("test_users"),
+                    )
+                )
+
+            await cursor.execute(
+                sql.SQL("""
+                    SELECT id
+                    FROM {jobs_table}
+                    WHERE func = %s
+                    AND state = 'pending'
+                """).format(jobs_table=sql.Identifier(f"{chancy.prefix}jobs")),
+                (handle_insert.job.func,),
+            )
+
+            jobs = await cursor.fetchall()
+            assert len(jobs) == 1, "Trigger in custom schema should create job"

--- a/tests/plugins/test_trigger.py
+++ b/tests/plugins/test_trigger.py
@@ -142,9 +142,9 @@ async def test_trigger_creates_job_on_change(
             )
 
             jobs = await cursor.fetchall()
-            assert (
-                len(jobs) == 0
-            ), "Trigger should not create jobs when disabled"
+            assert len(jobs) == 0, (
+                "Trigger should not create jobs when disabled"
+            )
 
 
 @pytest.mark.parametrize(
@@ -196,9 +196,9 @@ async def test_trigger_update_operation(chancy: Chancy, worker, test_table):
             )
 
             jobs = await cursor.fetchall()
-            assert (
-                len(jobs) == 1
-            ), "UPDATE trigger should create exactly one job"
+            assert len(jobs) == 1, (
+                "UPDATE trigger should create exactly one job"
+            )
 
             ref = Reference(jobs[0][0])
             j = await chancy.wait_for_job(ref)
@@ -253,9 +253,9 @@ async def test_trigger_delete_operation(chancy: Chancy, worker, test_table):
             )
 
             jobs = await cursor.fetchall()
-            assert (
-                len(jobs) == 1
-            ), "DELETE trigger should create exactly one job"
+            assert len(jobs) == 1, (
+                "DELETE trigger should create exactly one job"
+            )
 
             ref = Reference(jobs[0][0])
             j = await chancy.wait_for_job(ref)
@@ -321,9 +321,9 @@ async def test_trigger_multiple_operations(chancy: Chancy, worker, test_table):
             )
 
             jobs = await cursor.fetchall()
-            assert (
-                len(jobs) == 3
-            ), f"Should create 3 jobs (INSERT, UPDATE, DELETE), got {len(jobs)}"
+            assert len(jobs) == 3, (
+                f"Should create 3 jobs (INSERT, UPDATE, DELETE), got {len(jobs)}"
+            )
 
             # Wait for all jobs to complete
             for job_row in jobs:
@@ -612,9 +612,9 @@ async def test_trigger_bulk_operations(chancy: Chancy, worker, test_table):
 
             jobs = await cursor.fetchall()
             # Statement-level trigger should fire once per statement, not per row
-            assert (
-                len(jobs) == 1
-            ), "Statement-level trigger should create 1 job for bulk insert"
+            assert len(jobs) == 1, (
+                "Statement-level trigger should create 1 job for bulk insert"
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/plugins/test_workflow.py
+++ b/tests/plugins/test_workflow.py
@@ -331,8 +331,9 @@ async def test_simple_circular_dependency(chancy: Chancy, worker):
     with pytest.raises(CircularDependencyError) as exc_info:
         await WorkflowPlugin.push(chancy, workflow)
 
-    assert "step_a -> step_b -> step_a" in str(exc_info.value) or \
-           "step_b -> step_a -> step_b" in str(exc_info.value)
+    assert "step_a -> step_b -> step_a" in str(
+        exc_info.value
+    ) or "step_b -> step_a -> step_b" in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/tests/plugins/test_workflow.py
+++ b/tests/plugins/test_workflow.py
@@ -2,7 +2,13 @@ import asyncio
 import pytest
 
 from chancy import Chancy, Queue, job
-from chancy.plugins.workflow import Workflow, WorkflowPlugin, Sequence
+from chancy.plugins.workflow import (
+    Workflow,
+    WorkflowPlugin,
+    Sequence,
+    CircularDependencyError,
+    InvalidDependencyError,
+)
 from chancy.plugins.leadership import ImmediateLeadership
 from chancy.utils import chancy_uuid
 
@@ -297,3 +303,183 @@ async def test_workflow_with_modified_jobs(chancy: Chancy, worker):
     assert len(result.steps) == 2
     for step in result.steps.values():
         assert step.state == step.state.SUCCEEDED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chancy",
+    [
+        {
+            "plugins": [ImmediateLeadership(), WorkflowPlugin()],
+            "no_default_plugins": True,
+        },
+    ],
+    indirect=True,
+)
+async def test_simple_circular_dependency(chancy: Chancy, worker):
+    """
+    Test that a simple circular dependency (A -> B -> A) is detected.
+    """
+    await chancy.declare(Queue("default"))
+
+    workflow = (
+        Workflow("circular")
+        .add("step_a", sync_success, ["step_b"])
+        .add("step_b", sync_success, ["step_a"])
+    )
+
+    with pytest.raises(CircularDependencyError) as exc_info:
+        await WorkflowPlugin.push(chancy, workflow)
+
+    assert "step_a -> step_b -> step_a" in str(exc_info.value) or \
+           "step_b -> step_a -> step_b" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chancy",
+    [
+        {
+            "plugins": [ImmediateLeadership(), WorkflowPlugin()],
+            "no_default_plugins": True,
+        },
+    ],
+    indirect=True,
+)
+async def test_complex_circular_dependency(chancy: Chancy, worker):
+    """
+    Test that a complex circular dependency (A -> B -> C -> A) is detected.
+    """
+    await chancy.declare(Queue("default"))
+
+    workflow = (
+        Workflow("circular")
+        .add("step_a", sync_success, ["step_c"])
+        .add("step_b", sync_success, ["step_a"])
+        .add("step_c", sync_success, ["step_b"])
+    )
+
+    with pytest.raises(CircularDependencyError) as exc_info:
+        await WorkflowPlugin.push(chancy, workflow)
+
+    assert "Circular dependency detected" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chancy",
+    [
+        {
+            "plugins": [ImmediateLeadership(), WorkflowPlugin()],
+            "no_default_plugins": True,
+        },
+    ],
+    indirect=True,
+)
+async def test_self_dependency(chancy: Chancy, worker):
+    """
+    Test that a self-dependency (A -> A) is detected.
+    """
+    await chancy.declare(Queue("default"))
+
+    workflow = Workflow("self_dep").add("step_a", sync_success, ["step_a"])
+
+    with pytest.raises(CircularDependencyError) as exc_info:
+        await WorkflowPlugin.push(chancy, workflow)
+
+    assert "step_a" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chancy",
+    [
+        {
+            "plugins": [ImmediateLeadership(), WorkflowPlugin()],
+            "no_default_plugins": True,
+        },
+    ],
+    indirect=True,
+)
+async def test_invalid_dependency_reference(chancy: Chancy, worker):
+    """
+    Test that referencing a non-existent step is detected.
+    """
+    await chancy.declare(Queue("default"))
+
+    workflow = (
+        Workflow("invalid_dep")
+        .add("step_a", sync_success)
+        .add("step_b", sync_success, ["non_existent_step"])
+    )
+
+    with pytest.raises(InvalidDependencyError) as exc_info:
+        await WorkflowPlugin.push(chancy, workflow)
+
+    assert "step_b" in str(exc_info.value)
+    assert "non_existent_step" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_validate_can_be_called_independently():
+    """
+    Test that validate() can be called independently without pushing.
+    """
+    # Valid workflow should not raise
+    valid_workflow = (
+        Workflow("valid")
+        .add("step1", sync_success)
+        .add("step2", sync_success, ["step1"])
+        .add("step3", sync_success, ["step2"])
+    )
+    valid_workflow.validate()  # Should not raise
+
+    # Invalid workflow should raise
+    invalid_workflow = (
+        Workflow("invalid")
+        .add("step_a", sync_success, ["step_b"])
+        .add("step_b", sync_success, ["step_a"])
+    )
+    with pytest.raises(CircularDependencyError):
+        invalid_workflow.validate()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chancy",
+    [
+        {
+            "plugins": [ImmediateLeadership(), WorkflowPlugin()],
+            "no_default_plugins": True,
+        },
+    ],
+    indirect=True,
+)
+async def test_complex_valid_dag(chancy: Chancy, worker):
+    """
+    Test that a complex but valid DAG passes validation.
+    """
+    await chancy.declare(Queue("default"))
+
+    # Create a diamond-shaped DAG: start -> a,b -> c,d -> end
+    workflow = (
+        Workflow("complex_dag")
+        .add("start", sync_success)
+        .add_group(
+            [("a", sync_success), ("b", sync_success)],
+            ["start"],
+        )
+        .add_group(
+            [("c", sync_success), ("d", sync_success)],
+            ["a", "b"],
+        )
+        .add("end", sync_success, ["c", "d"])
+    )
+
+    # Should not raise - this is a valid DAG
+    workflow_id = await WorkflowPlugin.push(chancy, workflow)
+    result = await WorkflowPlugin.wait_for_workflow(
+        chancy, workflow_id, timeout=30
+    )
+
+    assert result.state == Workflow.State.COMPLETED

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -266,3 +266,52 @@ async def test_job_ordering(chancy: Chancy, worker: Worker):
     by_uuid7 = sorted(completed, key=lambda x: x.id)
 
     assert by_completed_at == by_uuid7
+
+
+@pytest.mark.asyncio
+async def test_retry_jobs(chancy: Chancy, worker: Worker):
+    """
+    Ensure that retrying a failed job requeues it and executes again.
+    """
+    await chancy.declare(Queue("default"))
+
+    ref = await chancy.push(Job.from_func(job_that_fails, max_attempts=1))
+    j1 = await chancy.wait_for_job(ref, timeout=30)
+    assert j1 is not None
+    assert j1.state == QueuedJob.State.FAILED
+
+    errors_before = len(j1.errors)
+
+    # Retry the job and ensure it runs again (and fails again).
+    await chancy.retry_jobs([ref])
+
+    j2 = await chancy.wait_for_job(ref, timeout=30)
+    assert j2 is not None
+    assert j2.state == QueuedJob.State.FAILED
+    # Attempts are reset on retry and incremented by the next run.
+    assert j2.attempts == 1
+    # We preserve error history; another attempt should add a new error.
+    assert len(j2.errors) >= errors_before + 1
+
+
+@pytest.mark.asyncio
+async def test_purge_jobs(chancy: Chancy, worker: Worker, sync_executor: str):
+    """
+    Ensure that purging jobs removes them permanently.
+    """
+    # Create a succeeded job
+    await chancy.declare(Queue("low", executor=sync_executor))
+    ref_ok = await chancy.push(job_to_run.job.with_queue("low"))
+    j_ok = await chancy.wait_for_job(ref_ok, timeout=30)
+    assert j_ok is not None and j_ok.state == QueuedJob.State.SUCCEEDED
+
+    # Create a failed job
+    await chancy.declare(Queue("default"))
+    ref_fail = await chancy.push(Job.from_func(job_that_fails, max_attempts=1))
+    j_fail = await chancy.wait_for_job(ref_fail, timeout=30)
+    assert j_fail is not None and j_fail.state == QueuedJob.State.FAILED
+
+    # Purge both and ensure they're gone
+    await chancy.purge_jobs([ref_ok, ref_fail])
+    assert await chancy.get_job(ref_ok) is None
+    assert await chancy.get_job(ref_fail) is None


### PR DESCRIPTION
0.25.1
------

✨ Improvements

- Added the Trigger plugin, which allows you to start jobs when arbitrary
  database events occur, such as inserts, updates, or deletes.
- Ensure `fetch_workflows_ex` always has guaranteed deterministic ordering of
  the returned workflow steps.
- Workflow's now validate before pushing, ensuring workflows with circular
  dependencies or invalid dependencies cannot be created.
- Test against PostgreSQL 18 and Python 3.14.
- The metrics plugin now tracks metrics on its own operations.
- Added `Chancy.purge_jobs()` and `Chancy.retry_jobs()` to bulk purge or
  retry specific jobs by reference.
- Added `_ex` versions of `purge_jobs`, `retry_jobs`, `pause_queue`,
  `resume_queue`, `delete_queue`, and `cancel_job` to allow passing in a
  cursor for transactional operations.

🐛 Fixes

- Fix a workflow's on_single_step_completed potentially running after the
  worker has lost leadership. Due to the workflow lock, this could not have
  resulted in duplicate work