### PR TITLE
Acquire job row locks in a consistent order to prevent deadlocks (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ Changelog
 - Fixed a very rare split-brain issue where a worker becoming the leader could
   extend the leadership of the previous leader, causing duplicate work for 1
   cycle.
+- Pushing jobs with unique keys and the worker's batched job updates now lock
+  rows in the same order, fixing a deadlock between overlapping pushes and
+  updates that could fail either side (@AudeCstg, #89).
 
 0.25.1
 ------

--- a/chancy/app.py
+++ b/chancy/app.py
@@ -674,14 +674,20 @@ class Chancy:
         :param jobs: The jobs to push onto the queue.
         :return: A list of references to the jobs in the queue.
         """
-        references = []
-        for job in jobs:
+        # Lock ordering: push jobs sorted by unique_key so concurrent worker
+        # UPDATE transactions acquire row locks in the same order and cannot
+        # deadlock (see CAP-1073). References are returned in the caller's
+        # original order to preserve the public API contract.
+        references: list[Reference | None] = [None] * len(jobs)
+        for original_index, job in sorted(
+            enumerate(jobs), key=lambda pair: self._job_unique_key(pair[1])
+        ):
             await cursor.execute(
                 self._push_job_sql(),
                 self._get_job_params(job),
             )
             record = await cursor.fetchone()
-            references.append(Reference(record["id"]))
+            references[original_index] = Reference(record["id"])
 
         if self.notifications:
             for queue in set(
@@ -710,14 +716,17 @@ class Chancy:
         :param jobs: The jobs to push onto the queue.
         :return: A list of references to the jobs in the queue.
         """
-        references = []
-        for job in jobs:
+        # Lock ordering: see push_many_ex for rationale (CAP-1073).
+        references: list[Reference | None] = [None] * len(jobs)
+        for original_index, job in sorted(
+            enumerate(jobs), key=lambda pair: self._job_unique_key(pair[1])
+        ):
             cursor.execute(
                 self._push_job_sql(),
                 self._get_job_params(job),
             )
             record = cursor.fetchone()
-            references.append(Reference(record["id"]))
+            references[original_index] = Reference(record["id"])
 
         for queue in set(job.queue for job in jobs):
             self.sync_notify(cursor, "queue.pushed", {"q": queue})
@@ -1247,6 +1256,12 @@ class Chancy:
             queues=sql.Identifier(f"{self.prefix}queues"),
             action=action,
         )
+
+    @staticmethod
+    def _job_unique_key(job: Job | IsAJob[..., Any]) -> str:
+        if callable(job):
+            job = job.job
+        return job.unique_key or ""
 
     @staticmethod
     def _get_job_params(job: Job | IsAJob[..., Any]) -> dict:

--- a/chancy/app.py
+++ b/chancy/app.py
@@ -678,7 +678,7 @@ class Chancy:
         # UPDATE transactions acquire row locks in the same order and cannot
         # deadlock (see CAP-1073). References are returned in the caller's
         # original order to preserve the public API contract.
-        references: list[Reference | None] = [None] * len(jobs)
+        references_by_index: dict[int, Reference] = {}
         for original_index, job in sorted(
             enumerate(jobs), key=lambda pair: self._job_unique_key(pair[1])
         ):
@@ -687,7 +687,7 @@ class Chancy:
                 self._get_job_params(job),
             )
             record = await cursor.fetchone()
-            references[original_index] = Reference(record["id"])
+            references_by_index[original_index] = Reference(record["id"])
 
         if self.notifications:
             for queue in set(
@@ -696,7 +696,7 @@ class Chancy:
             ):
                 await self.notify(cursor, "queue.pushed", {"q": queue})
 
-        return references
+        return [references_by_index[i] for i in range(len(jobs))]
 
     def sync_push_many_ex(
         self, cursor: Cursor, jobs: list[Job]
@@ -717,7 +717,7 @@ class Chancy:
         :return: A list of references to the jobs in the queue.
         """
         # Lock ordering: see push_many_ex for rationale (CAP-1073).
-        references: list[Reference | None] = [None] * len(jobs)
+        references_by_index: dict[int, Reference] = {}
         for original_index, job in sorted(
             enumerate(jobs), key=lambda pair: self._job_unique_key(pair[1])
         ):
@@ -726,12 +726,12 @@ class Chancy:
                 self._get_job_params(job),
             )
             record = cursor.fetchone()
-            references[original_index] = Reference(record["id"])
+            references_by_index[original_index] = Reference(record["id"])
 
         for queue in set(job.queue for job in jobs):
             self.sync_notify(cursor, "queue.pushed", {"q": queue})
 
-        return references
+        return [references_by_index[i] for i in range(len(jobs))]
 
     @_ensure_pool_is_open
     async def get_job(self, ref: Reference) -> QueuedJob | None:
@@ -1259,9 +1259,8 @@ class Chancy:
 
     @staticmethod
     def _job_unique_key(job: Job | IsAJob[..., Any]) -> str:
-        if callable(job):
-            job = job.job
-        return job.unique_key or ""
+        actual = job if isinstance(job, Job) else job.job
+        return actual.unique_key or ""
 
     @staticmethod
     def _get_job_params(job: Job | IsAJob[..., Any]) -> dict:

--- a/chancy/app.py
+++ b/chancy/app.py
@@ -22,6 +22,7 @@ from chancy.utils import (
     chunked,
     get_database_dsn,
     json_dumps,
+    lock_order_key,
 )
 
 
@@ -689,14 +690,17 @@ class Chancy:
         :param jobs: The jobs to push onto the queue.
         :return: A list of references to the jobs in the queue.
         """
-        references = []
-        for job in jobs:
+        # Jobs are inserted in unique_key order so that concurrent pushes and
+        # the worker's batched job updates (which sort the same way) always
+        # acquire row locks in the same order and cannot deadlock (#89).
+        references: list[Reference | None] = [None] * len(jobs)
+        for index, job in self._in_lock_order(jobs):
             await cursor.execute(
                 self._push_job_sql(),
                 self._get_job_params(job),
             )
             record = await cursor.fetchone()
-            references.append(Reference(record["id"]))
+            references[index] = Reference(record["id"])
 
         if self.notifications:
             for queue in {
@@ -725,14 +729,15 @@ class Chancy:
         :param jobs: The jobs to push onto the queue.
         :return: A list of references to the jobs in the queue.
         """
-        references = []
-        for job in jobs:
+        # See push_many_ex for why jobs are inserted in unique_key order.
+        references: list[Reference | None] = [None] * len(jobs)
+        for index, job in self._in_lock_order(jobs):
             cursor.execute(
                 self._push_job_sql(),
                 self._get_job_params(job),
             )
             record = cursor.fetchone()
-            references.append(Reference(record["id"]))
+            references[index] = Reference(record["id"])
 
         for queue in {job.queue for job in jobs}:
             self.sync_notify(cursor, "queue.pushed", {"q": queue})
@@ -1497,6 +1502,26 @@ class Chancy:
         ).format(
             queues=sql.Identifier(f"{self.prefix}queues"),
             action=action,
+        )
+
+    @staticmethod
+    def _in_lock_order(
+        jobs: list[Job | IsAJob[..., Any]],
+    ) -> list[tuple[int, Job | IsAJob[..., Any]]]:
+        """
+        Pair each job with its original index and order the pairs by
+        unique_key, which is the order in which row locks must be acquired.
+
+        Jobs without a unique_key never conflict with an existing row, so
+        their relative order does not matter and they are grouped first.
+        """
+        return sorted(
+            enumerate(jobs),
+            key=lambda pair: lock_order_key(
+                (
+                    pair[1] if isinstance(pair[1], Job) else pair[1].job
+                ).unique_key
+            ),
         )
 
     @staticmethod

--- a/chancy/utils.py
+++ b/chancy/utils.py
@@ -122,6 +122,18 @@ def import_string(name):
     return getattr(module, func_name)
 
 
+def lock_order_key(unique_key: str | None) -> str:
+    """
+    The key used to order job rows before locking them.
+
+    Every code path that takes row locks on several jobs in one transaction
+    (pushing jobs with unique keys, the worker's batched job updates) must
+    sort by this key so that overlapping transactions acquire their locks in
+    the same order and cannot deadlock. See issue #89.
+    """
+    return unique_key or ""
+
+
 def chancy_uuid() -> uuid.UUID:
     """
     Generate a UUID suitable for use as a job ID.

--- a/chancy/worker.py
+++ b/chancy/worker.py
@@ -470,83 +470,6 @@ class Worker:
             j = json.loads(notification.payload)
             await self.hub.emit(j.pop("t"), j)
 
-    async def _flush_updates(self, pending_updates: list[QueuedJob]):
-        """
-        Flush pending job updates to the database.
-
-        On deadlock, retries once before re-raising. This prevents the
-        worker from crashing on transient deadlocks while still surfacing
-        the error for observability.
-        """
-        for attempt in range(2):
-            async with self.chancy.pool.connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cursor:
-                    async with conn.transaction():
-                        try:
-                            await cursor.executemany(
-                                sql.SQL(
-                                    """
-                                    UPDATE
-                                        {jobs}
-                                    SET
-                                        state = %(state)s,
-                                        started_at = %(started_at)s,
-                                        completed_at = %(completed_at)s,
-                                        scheduled_at = %(scheduled_at)s,
-                                        attempts = %(attempts)s,
-                                        errors = %(errors)s,
-                                        meta = %(meta)s,
-                                        max_attempts = %(max_attempts)s
-                                    WHERE
-                                        id = %(id)s
-                                    """
-                                ).format(
-                                    jobs=sql.Identifier(
-                                        f"{self.chancy.prefix}jobs"
-                                    )
-                                ),
-                                [
-                                    {
-                                        "id": update.id,
-                                        "state": update.state.value,
-                                        "started_at": update.started_at,
-                                        "completed_at": update.completed_at,
-                                        "scheduled_at": update.scheduled_at,
-                                        "attempts": update.attempts,
-                                        "errors": Json(update.errors),
-                                        "meta": Json(update.meta),
-                                        "max_attempts": update.max_attempts,
-                                    }
-                                    for update in pending_updates
-                                ],
-                            )
-                            return
-                        except DeadlockDetected:
-                            if attempt == 0:
-                                self.chancy.log.error(
-                                    "Deadlock detected while updating"
-                                    f" {len(pending_updates)} jobs,"
-                                    " retrying once."
-                                )
-                                continue
-
-                            self.chancy.log.exception(
-                                "Deadlock detected while updating"
-                                f" {len(pending_updates)} jobs,"
-                                " retry exhausted."
-                            )
-                            for update in pending_updates:
-                                await self.outgoing.put(update)
-                            raise
-                        except Exception:
-                            self.chancy.log.exception(
-                                "Failed to apply updates to job"
-                                " instances."
-                            )
-                            for update in pending_updates:
-                                await self.outgoing.put(update)
-                            raise
-
     async def _maintain_updates(self):
         """
         Process updates to job instances.
@@ -574,7 +497,82 @@ class Worker:
                 f"Processing {len(pending_updates)} outgoing updates."
             )
 
-            await self._flush_updates(pending_updates)
+            for attempt in range(2):
+                try:
+                    async with self.chancy.pool.connection() as conn:
+                        async with conn.cursor(
+                            row_factory=dict_row
+                        ) as cursor:
+                            async with conn.transaction():
+                                await cursor.executemany(
+                                    sql.SQL(
+                                        """
+                                        UPDATE
+                                            {jobs}
+                                        SET
+                                            state = %(state)s,
+                                            started_at = %(started_at)s,
+                                            completed_at = %(completed_at)s,
+                                            scheduled_at = %(scheduled_at)s,
+                                            attempts = %(attempts)s,
+                                            errors = %(errors)s,
+                                            meta = %(meta)s,
+                                            max_attempts = %(max_attempts)s
+                                        WHERE
+                                            id = %(id)s
+                                        """
+                                    ).format(
+                                        jobs=sql.Identifier(
+                                            f"{self.chancy.prefix}jobs"
+                                        )
+                                    ),
+                                    [
+                                        {
+                                            "id": update.id,
+                                            "state": update.state.value,
+                                            "started_at": update.started_at,
+                                            "completed_at": (
+                                                update.completed_at
+                                            ),
+                                            "scheduled_at": (
+                                                update.scheduled_at
+                                            ),
+                                            "attempts": update.attempts,
+                                            "errors": Json(update.errors),
+                                            "meta": Json(update.meta),
+                                            "max_attempts": (
+                                                update.max_attempts
+                                            ),
+                                        }
+                                        for update in pending_updates
+                                    ],
+                                )
+                    break
+                except DeadlockDetected:
+                    if attempt < 1:
+                        self.chancy.log.error(
+                            "Deadlock detected while updating"
+                            f" {len(pending_updates)} jobs,"
+                            " retrying once."
+                        )
+                        await asyncio.sleep(0.1)
+                        continue
+
+                    self.chancy.log.exception(
+                        "Deadlock detected while updating"
+                        f" {len(pending_updates)} jobs,"
+                        " retry exhausted."
+                    )
+                    for update in pending_updates:
+                        await self.outgoing.put(update)
+                    raise
+                except Exception:
+                    self.chancy.log.exception(
+                        "Failed to apply updates to job instances."
+                    )
+                    for update in pending_updates:
+                        await self.outgoing.put(update)
+                    raise
 
             for update in pending_updates:
                 for plugin in self.chancy.plugins.values():

--- a/chancy/worker.py
+++ b/chancy/worker.py
@@ -125,6 +125,9 @@ class Worker:
     :param register_signal_handlers: Whether to register signal handlers.
     """
 
+    #: Maximum number of retries on deadlock before re-raising.
+    DEADLOCK_MAX_RETRIES = 1
+
     def __init__(
         self,
         chancy: Chancy,
@@ -497,12 +500,10 @@ class Worker:
                 f"Processing {len(pending_updates)} outgoing updates."
             )
 
-            for attempt in range(2):
+            for attempt in range(self.DEADLOCK_MAX_RETRIES + 1):
                 try:
                     async with self.chancy.pool.connection() as conn:
-                        async with conn.cursor(
-                            row_factory=dict_row
-                        ) as cursor:
+                        async with conn.cursor(row_factory=dict_row) as cursor:
                             async with conn.transaction():
                                 await cursor.executemany(
                                     sql.SQL(
@@ -549,7 +550,7 @@ class Worker:
                                 )
                     break
                 except DeadlockDetected:
-                    if attempt < 1:
+                    if attempt < self.DEADLOCK_MAX_RETRIES:
                         self.chancy.log.error(
                             "Deadlock detected while updating"
                             f" {len(pending_updates)} jobs,"

--- a/chancy/worker.py
+++ b/chancy/worker.py
@@ -14,6 +14,7 @@ from collections import defaultdict
 
 from psycopg import sql
 from psycopg import AsyncConnection
+from psycopg.errors import DeadlockDetected
 from psycopg.rows import dict_row
 from psycopg.types.json import Json
 
@@ -469,33 +470,15 @@ class Worker:
             j = json.loads(notification.payload)
             await self.hub.emit(j.pop("t"), j)
 
-    async def _maintain_updates(self):
+    async def _flush_updates(self, pending_updates: list[QueuedJob]):
         """
-        Process updates to job instances.
+        Flush pending job updates to the database.
 
-        We maintain a queue of updates to job instances, and process them in
-        batches to significantly reduce the number of overall transactions that
-        need to be made, at the cost of potentially losing some updates if the
-        worker is stopped unexpectedly. The frequency of these updates can be
-        controlled by setting the `send_outgoing_interval` attribute on the
-        worker.
+        On deadlock, retries once before re-raising. This prevents the
+        worker from crashing on transient deadlocks while still surfacing
+        the error for observability.
         """
-        while True:
-            if self.outgoing.empty():
-                await asyncio.sleep(self.send_outgoing_interval)
-                continue
-
-            pending_updates = []
-            while len(pending_updates) < 1000:
-                try:
-                    pending_updates.append(self.outgoing.get_nowait())
-                except asyncio.QueueEmpty:
-                    break
-
-            self.chancy.log.debug(
-                f"Processing {len(pending_updates)} outgoing updates."
-            )
-
+        for attempt in range(2):
             async with self.chancy.pool.connection() as conn:
                 async with conn.cursor(row_factory=dict_row) as cursor:
                     async with conn.transaction():
@@ -537,15 +520,61 @@ class Worker:
                                     for update in pending_updates
                                 ],
                             )
-                        except Exception:
-                            # If we were unable to apply the updates, we should
-                            # re-queue them for the next poll.
+                            return
+                        except DeadlockDetected:
+                            if attempt == 0:
+                                self.chancy.log.error(
+                                    "Deadlock detected while updating"
+                                    f" {len(pending_updates)} jobs,"
+                                    " retrying once."
+                                )
+                                continue
+
                             self.chancy.log.exception(
-                                "Failed to apply updates to job instances."
+                                "Deadlock detected while updating"
+                                f" {len(pending_updates)} jobs,"
+                                " retry exhausted."
                             )
                             for update in pending_updates:
                                 await self.outgoing.put(update)
                             raise
+                        except Exception:
+                            self.chancy.log.exception(
+                                "Failed to apply updates to job"
+                                " instances."
+                            )
+                            for update in pending_updates:
+                                await self.outgoing.put(update)
+                            raise
+
+    async def _maintain_updates(self):
+        """
+        Process updates to job instances.
+
+        We maintain a queue of updates to job instances, and process them in
+        batches to significantly reduce the number of overall transactions that
+        need to be made, at the cost of potentially losing some updates if the
+        worker is stopped unexpectedly. The frequency of these updates can be
+        controlled by setting the `send_outgoing_interval` attribute on the
+        worker.
+        """
+        while True:
+            if self.outgoing.empty():
+                await asyncio.sleep(self.send_outgoing_interval)
+                continue
+
+            pending_updates = []
+            while len(pending_updates) < 1000:
+                try:
+                    pending_updates.append(self.outgoing.get_nowait())
+                except asyncio.QueueEmpty:
+                    break
+
+            self.chancy.log.debug(
+                f"Processing {len(pending_updates)} outgoing updates."
+            )
+
+            await self._flush_updates(pending_updates)
 
             for update in pending_updates:
                 for plugin in self.chancy.plugins.values():

--- a/chancy/worker.py
+++ b/chancy/worker.py
@@ -496,6 +496,12 @@ class Worker:
                 except asyncio.QueueEmpty:
                     break
 
+            # Lock ordering: sort by unique_key so concurrent push_many_ex
+            # transactions acquire row locks in the same order and cannot
+            # deadlock. Jobs without a unique_key cannot collide via
+            # ON CONFLICT so grouping them first is safe.
+            pending_updates.sort(key=lambda u: (u.unique_key or "", u.id))
+
             self.chancy.log.debug(
                 f"Processing {len(pending_updates)} outgoing updates."
             )

--- a/chancy/worker.py
+++ b/chancy/worker.py
@@ -24,7 +24,7 @@ from chancy.hub import Event, Hub
 from chancy.job import QueuedJob, Reference
 from chancy.plugin import PluginScope
 from chancy.queue import Queue
-from chancy.utils import TaskManager, import_string, sleep
+from chancy.utils import TaskManager, import_string, lock_order_key, sleep
 
 
 class Worker:
@@ -634,6 +634,15 @@ class Worker:
 
             self.chancy.log.debug(
                 f"Processing {len(pending_updates)} outgoing updates."
+            )
+
+            # Lock rows in the same order as push_many_ex does, or a batch of
+            # updates overlapping a push of the same unique keys deadlocks.
+            pending_updates.sort(
+                key=lambda update: (
+                    lock_order_key(update.unique_key),
+                    update.id,
+                )
             )
 
             try:

--- a/tests/regressions/test_89.py
+++ b/tests/regressions/test_89.py
@@ -1,0 +1,87 @@
+import asyncio
+
+import pytest
+from psycopg import AsyncConnection, sql
+
+from chancy import Chancy, job
+from chancy.utils import lock_order_key
+
+
+@job()
+async def unique_job():
+    pass
+
+
+async def _push_all(chancy: Chancy, jobs):
+    return [ref async for refs in chancy.push_many(jobs) for ref in refs]
+
+
+@pytest.mark.asyncio
+async def test_regression_89(chancy: Chancy):
+    """
+    Pushing jobs whose unique keys already exist takes row locks (the
+    ON CONFLICT ... DO UPDATE clause), and so does the worker's batched job
+    update. When the two transactions overlap and lock the rows in a
+    different order, Postgres detects a deadlock and kills one of them.
+
+    This test replays the interleaving deterministically: one transaction
+    locks the rows in the order the worker uses, while a concurrent push
+    submits the same unique keys in the opposite order.
+    """
+    jobs = [
+        unique_job.job.with_unique_key("regression_89_b"),
+        unique_job.job.with_unique_key("regression_89_a"),
+    ]
+    references = await _push_all(chancy, jobs)
+    existing = await chancy.get_jobs(references)
+    # Same ordering rule as Worker._maintain_updates.
+    first, second = sorted(
+        existing, key=lambda j: (lock_order_key(j.unique_key), j.id)
+    )
+
+    lock_row = sql.SQL("UPDATE {jobs} SET meta = meta WHERE id = %s").format(
+        jobs=sql.Identifier(f"{chancy.prefix}jobs")
+    )
+
+    async with (
+        await AsyncConnection.connect(chancy.dsn) as conn,
+        conn.transaction(),
+    ):
+        await conn.execute("SET LOCAL deadlock_timeout = '100ms'")
+        await conn.execute(lock_row, [first.id])
+
+        push = asyncio.create_task(_push_all(chancy, jobs))
+        await asyncio.sleep(0.5)
+        assert not push.done(), "the push should be waiting on the first row"
+
+        # With inconsistent lock ordering, this raises DeadlockDetected here
+        # or in the push task.
+        await conn.execute(lock_row, [second.id])
+
+    assert await push == references
+
+
+@pytest.mark.asyncio
+async def test_regression_89_sync_push_preserves_order(chancy: Chancy):
+    """
+    Re-ordering the inserts must not re-order the returned references.
+    """
+    jobs = [
+        unique_job.job.with_unique_key("regression_89_sync_c"),
+        unique_job.job.with_unique_key("regression_89_sync_a"),
+        unique_job.job.with_unique_key("regression_89_sync_b"),
+        unique_job.job,
+    ]
+    with Chancy(chancy.dsn, prefix=chancy.prefix) as sync_chancy:
+        references = [
+            ref for refs in sync_chancy.sync_push_many(jobs) for ref in refs
+        ]
+
+    pushed = await chancy.get_jobs(references)
+    by_id = {j.id: j for j in pushed}
+    assert [by_id[ref.identifier].unique_key for ref in references] == [
+        "regression_89_sync_c",
+        "regression_89_sync_a",
+        "regression_89_sync_b",
+        None,
+    ]


### PR DESCRIPTION
PR to follow changes used by tags