### PR TITLE
Resolve PEP-563 string annotations when injecting QueuedJob context

### DIFF
--- a/chancy/executors/base.py
+++ b/chancy/executors/base.py
@@ -149,17 +149,36 @@ class Executor(abc.ABC):
         # We take a look at the type signature for the function to see if the
         # user has specified that the job instance should be passed as a
         # keyword argument.
+        #
+        # `typing.get_type_hints` resolves string annotations (PEP 563 /
+        # `from __future__ import annotations`) to their underlying
+        # classes. Without this, `param.annotation` is the bare string
+        # `"QueuedJob"`, and the `issubclass` check below raises
+        # TypeError on a string — silently swallowed — so the QueuedJob
+        # context is never injected. The decorated job then gets called
+        # without the required `context` keyword arg, and the resulting
+        # TypeError surfaces only via `_job_wrapper`'s except branch
+        # logged at DEBUG (see issue #57).
         sig = inspect.signature(func)
+        try:
+            type_hints = typing.get_type_hints(func)
+        except Exception:
+            # `get_type_hints` can fail when an annotation references a
+            # name not visible in the function's globals (forward refs
+            # resolved elsewhere). Fall back to raw `param.annotation`
+            # so non-stringified annotations keep working.
+            type_hints = {}
         kwargs = job.kwargs or {}
         for param_name, param in sig.parameters.items():
             if not param.kind == param.KEYWORD_ONLY:
                 continue
 
-            if not param.annotation:
+            annotation = type_hints.get(param_name, param.annotation)
+            if not annotation or annotation is inspect.Parameter.empty:
                 continue
 
             try:
-                if issubclass(param.annotation, QueuedJob):
+                if issubclass(annotation, QueuedJob):
                     kwargs[param_name] = job
             except TypeError:
                 continue

--- a/tests/test_pep_563_annotations.py
+++ b/tests/test_pep_563_annotations.py
@@ -1,0 +1,80 @@
+"""Regression test for `from __future__ import annotations` (PEP 563).
+
+`Executor.get_function_and_kwargs` inspects the job function's
+signature to detect a `context: QueuedJob` keyword-only parameter and
+inject the QueuedJob instance into the kwargs. Before the fix,
+`param.annotation` returned the bare string `"QueuedJob"` when the
+defining module used `from __future__ import annotations`. The
+subsequent `issubclass(param.annotation, QueuedJob)` raised TypeError
+on a string, the catch swallowed it, and the function was then called
+without the required `context` arg — a TypeError logged only at DEBUG
+on chancy's stdlib logger.
+
+The fix resolves annotations via `typing.get_type_hints(func)` first,
+falling back to `param.annotation` when resolution fails (e.g.
+forward references unresolvable in the function's globals).
+
+This test is purely static — it does not require a Postgres
+connection or a running worker; it drives
+`Executor.get_function_and_kwargs` directly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from chancy import QueuedJob, job
+from chancy.executors.base import Executor
+
+
+@job()
+async def _job_with_future_annotations(execution_id: str, *, context: QueuedJob) -> None:
+    """Job with `from __future__ import annotations` at module top.
+
+    The annotation `context: QueuedJob` is stored as the string
+    `"QueuedJob"` at runtime under PEP 563.
+    """
+    del context, execution_id
+
+
+def _build_queued_job(func) -> QueuedJob:
+    """Mirror what chancy would have stored after `chancy.push(...)`."""
+    template = func.job
+    return QueuedJob(
+        id="test-job",
+        func=template.func,
+        kwargs={**(template.kwargs or {}), "execution_id": "abc"},
+        queue=template.queue,
+        priority=template.priority,
+        max_attempts=template.max_attempts,
+        scheduled_at=template.scheduled_at,
+        created_at=datetime.now(tz=timezone.utc),
+        attempts=0,
+        limits=template.limits,
+        unique_key=template.unique_key,
+        meta=template.meta,
+    )
+
+
+def test_get_function_and_kwargs_resolves_future_annotations() -> None:
+    """Context injection works when the @job module uses PEP 563.
+
+    Before the fix this assertion failed because `param.annotation`
+    was the string `"QueuedJob"` and chancy's `issubclass` check
+    raised TypeError (silently swallowed).
+    """
+    queued = _build_queued_job(_job_with_future_annotations)
+
+    func, kwargs = Executor.get_function_and_kwargs(queued)
+
+    assert func is _job_with_future_annotations
+    assert "context" in kwargs, (
+        "QueuedJob context was not injected — likely because the "
+        "annotation was a stringified `QueuedJob` (PEP 563) and "
+        "`issubclass(str, QueuedJob)` swallowed silently. See fix in "
+        "chancy/executors/base.py."
+    )
+    assert isinstance(kwargs["context"], QueuedJob)
+    # The user-provided kwarg must also round-trip alongside the
+    # injected context.
+    assert kwargs["execution_id"] == "abc"


### PR DESCRIPTION
## Summary

`Executor.get_function_and_kwargs` (`chancy/executors/base.py`) walks `inspect.signature(func)` and calls `issubclass(param.annotation, QueuedJob)` to decide whether to inject the QueuedJob instance for a `context:` kwarg. This works when annotations are real classes — but if the `@job` module uses `from __future__ import annotations` (PEP 563), every annotation is the bare string of its source. `issubclass(str, QueuedJob)` raises `TypeError`, the surrounding `except TypeError: continue` swallows it, and the context is never injected.

The decorated job then gets called *without* the required `context` keyword argument, raising a `TypeError` inside `_job_wrapper`. That exception is logged at `DEBUG` on `self.worker.chancy.log` — which defaults to `WARNING` on the Python root logger, so the failure is invisible unless a downstream project explicitly lowers the chancy logger level. The execution stays stuck in `running` forever and no error trail surfaces anywhere.

## The fix

Resolve annotations via `typing.get_type_hints(func)` (which handles PEP 563 by evaluating string annotations against the function's globals) and look up `param_name` there before falling back to `param.annotation`. The fallback preserves the existing behaviour for cases where `get_type_hints` can't resolve (e.g. forward refs to names not in the function's globals).

## Test

New `tests/test_pep_563_annotations.py` defines a `@job` function in a module with `from __future__ import annotations` and asserts `Executor.get_function_and_kwargs` injects the QueuedJob context. The test is self-contained (no Postgres or worker needed) and:

- **Fails** on `main` (`b0e3e94`) before this patch.
- **Passes** with the patch applied.

```text
$ pytest tests/test_pep_563_annotations.py -v
tests/test_pep_563_annotations.py::test_get_function_and_kwargs_resolves_future_annotations PASSED
```

Happy to iterate on the patch — for instance using `inspect.signature(func, eval_str=True)` (Python 3.10+) would also work, but `typing.get_type_hints` felt closer to the canonical "PEP-563 unstringifier."