### PR TITLE
fix(process): recover from broken process pool

### DIFF
--- a/chancy/executors/process.py
+++ b/chancy/executors/process.py
@@ -14,6 +14,7 @@ except ImportError:
 import signal
 from asyncio import Future, CancelledError
 from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from typing import Callable, Any
 
 from chancy import Reference
@@ -70,15 +71,20 @@ class ProcessExecutor(ConcurrentExecutor):
         # We're using `spawn` explicitly to get ahead of the curve, however
         # this is slower than `fork`.
         ctx = mp_context or multiprocessing.get_context("spawn")
+        self._mp_context = ctx
+        self._max_tasks_per_child = maximum_jobs_per_worker
 
         self.manager = ctx.Manager()
         self.pids_for_job = self.manager.dict()
         self.timeouts: dict[str, asyncio.Task] = {}
-        self.pool = ProcessPoolExecutor(
-            max_workers=queue.concurrency,
-            max_tasks_per_child=maximum_jobs_per_worker,
+        self.pool = self._create_pool()
+
+    def _create_pool(self) -> ProcessPoolExecutor:
+        return ProcessPoolExecutor(
+            max_workers=self.queue.concurrency,
+            max_tasks_per_child=self._max_tasks_per_child,
             initializer=self.on_initialize_worker,
-            mp_context=ctx,
+            mp_context=self._mp_context,
         )
 
     @classmethod
@@ -111,17 +117,33 @@ class ProcessExecutor(ConcurrentExecutor):
 
             django.setup()
 
-    async def push(self, job: QueuedJob) -> Future:
+    async def push(self, job: QueuedJob) -> Future | None:
         job = await self.on_job_starting(job)
 
-        future: Future = self.pool.submit(
-            self.job_wrapper, job, self.pids_for_job
-        )
-        future.add_done_callback(
-            functools.partial(
-                self._on_job_completed, loop=asyncio.get_running_loop()
+        loop = asyncio.get_running_loop()
+        callback = functools.partial(self._on_job_completed, loop=loop)
+
+        try:
+            future: Future = self.pool.submit(
+                self.job_wrapper, job, self.pids_for_job
             )
-        )
+        except BrokenProcessPool:
+            old = self.pool
+            self.pool = self._create_pool()
+            old.shutdown(wait=False)
+            self.worker.chancy.log.warning(
+                "ProcessExecutor: pool was broken; recreated. Retrying job %s.",
+                job.id,
+            )
+            try:
+                future = self.pool.submit(
+                    self.job_wrapper, job, self.pids_for_job
+                )
+            except BrokenProcessPool as exc2:
+                await self.on_job_completed(job=job, exc=exc2, result=None)
+                return None
+
+        future.add_done_callback(callback)
         self.jobs[future] = job
         time_limit = next(
             (
@@ -234,6 +256,8 @@ class ProcessExecutor(ConcurrentExecutor):
         timeout_task = self.timeouts.pop(job.id, None)
         if timeout_task is not None:
             timeout_task.cancel()
+
+        self.pids_for_job.pop(job.id, None)
 
         result = None
         exc = future.exception()

--- a/tests/regressions/test_94.py
+++ b/tests/regressions/test_94.py
@@ -1,0 +1,96 @@
+import os
+import time
+
+import pytest
+
+from chancy import Chancy, Worker, Queue, Job, QueuedJob
+
+
+def killer_job():
+    os._exit(1)
+
+
+def normal_job():
+    return "ok"
+
+
+def brief_sleep_job():
+    time.sleep(0.5)
+    return "ok"
+
+
+@pytest.mark.asyncio
+async def test_regression_94_worker_survives_and_pool_recovers(
+    chancy: Chancy, worker: Worker
+):
+    """
+    A job that kills its subprocess abruptly must not permanently break the
+    pool or terminate the worker. After the offending job is dead-lettered, a
+    subsequent normal job on the same queue must succeed (criteria 1, 3, 4).
+    """
+    await chancy.declare(
+        Queue(
+            "proc-recover",
+            concurrency=1,
+            executor=Chancy.Executor.Process,
+        )
+    )
+
+    killer_ref = await chancy.push(
+        Job.from_func(killer_job, queue="proc-recover", max_attempts=2)
+    )
+
+    failed_job = await chancy.wait_for_job(killer_ref, timeout=120, interval=1)
+
+    assert failed_job.state == QueuedJob.State.FAILED, (
+        f"expected FAILED, got {failed_job.state}"
+    )
+    assert failed_job.attempts == 2, (
+        f"expected 2 attempts, got {failed_job.attempts}"
+    )
+    assert failed_job.max_attempts == 2, (
+        f"max_attempts inflated to {failed_job.max_attempts} (should stay 2)"
+    )
+
+    normal_ref = await chancy.push(
+        Job.from_func(normal_job, queue="proc-recover")
+    )
+    normal_completed = await chancy.wait_for_job(
+        normal_ref, timeout=60, interval=1
+    )
+    assert normal_completed.state == QueuedJob.State.SUCCEEDED, (
+        f"pool did not recover — normal job ended {normal_completed.state}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_regression_94_concurrent_job_survives_broken_pool(
+    chancy: Chancy, worker: Worker
+):
+    """
+    With concurrency=2, a normal job running alongside the killer must not be
+    silently lost — it should ultimately end in SUCCEEDED (criterion 2).
+    """
+    await chancy.declare(
+        Queue(
+            "proc-concurrent",
+            concurrency=2,
+            executor=Chancy.Executor.Process,
+        )
+    )
+
+    killer_ref = await chancy.push(
+        Job.from_func(killer_job, queue="proc-concurrent", max_attempts=1)
+    )
+    innocent_ref = await chancy.push(
+        Job.from_func(brief_sleep_job, queue="proc-concurrent", max_attempts=3)
+    )
+
+    await chancy.wait_for_job(killer_ref, timeout=120, interval=1)
+
+    innocent_job = await chancy.wait_for_job(
+        innocent_ref, timeout=120, interval=1
+    )
+    assert innocent_job.state == QueuedJob.State.SUCCEEDED, (
+        f"innocent job was not SUCCEEDED — got {innocent_job.state}"
+    )


### PR DESCRIPTION
Fixes #94.

**Why?**
When a subprocess dies abruptly (via `os._exit()`, a signal, OOM, or an exception that can't be pickled back to the parent), `concurrent.futures` marks the pool as broken and raises `BrokenProcessPool` on every subsequent `submit()` call. This exception escaped `ProcessExecutor.push()` into the worker's job-pull loop, killing the entire worker — triggering crash-restart loops under a supervisor and unbounded `max_attempts` inflation via the Recovery plugin.

**How?**
Pool construction is extracted into a `_create_pool()` helper. In `push()`, the `pool.submit()` call is wrapped in a `try/except BrokenProcessPool`: on failure the broken pool is replaced with a fresh one (`old.shutdown(wait=False)`), and the submit is retried once. If the retry also raises, the job is routed through `on_job_completed(exc=...)` inline so it fails/retries per its own `max_attempts` without `BrokenProcessPool` ever reaching the worker loop. A defensive `pids_for_job.pop()` is added to `_on_job_completed` to clean up entries left by processes that died before their `finally` block ran.